### PR TITLE
run unit tests in PR checks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,172 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-changes:
+    name: Check what files changed
+    runs-on: ubuntu-latest
+    outputs:
+      opa-evaluator: ${{ steps.changes.outputs.opa-evaluator }}
+      opa-jackson: ${{ steps.changes.outputs.opa-jackson }}
+      opa-services: ${{ steps.changes.outputs.opa-services }}
+      opa-builtins: ${{ steps.changes.outputs.opa-builtins }}
+      opa-slf4j: ${{ steps.changes.outputs.opa-slf4j }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download OPA
+        uses: open-policy-agent/setup-opa@v2
+        with:
+          version: latest
+
+      - name: Check for file changes
+        id: changes
+        run: |
+          set -e
+
+          echo "opa-evaluator=true" >> $GITHUB_OUTPUT
+          echo "opa-jackson=true" >> $GITHUB_OUTPUT
+          echo "opa-services=true" >> $GITHUB_OUTPUT
+          echo "opa-builtins=true" >> $GITHUB_OUTPUT
+          echo "opa-slf4j=true" >> $GITHUB_OUTPUT
+
+          if ! curl -s -o changed_files.json -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"; then
+            echo "Failed to fetch changed files, defaulting to running all checks"
+            exit 0
+          fi
+
+          if [ ! -s changed_files.json ]; then
+            echo "No changed files found, defaulting to running all checks"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          jq -r '.[].filename' changed_files.json
+
+          opa eval \
+            --data tools/policy/pr-check/pr_check.rego \
+            --input changed_files.json \
+            --format pretty \
+            'data.policy["pr-check"]' > opa_result.json
+
+          echo "OPA result:"
+          cat opa_result.json
+
+          opa_evaluator=$(jq -r '.changes["opa-evaluator"] // false' opa_result.json)
+          opa_jackson=$(jq -r '.changes["opa-jackson"] // false' opa_result.json)
+          opa_services=$(jq -r '.changes["opa-services"] // false' opa_result.json)
+          opa_builtins=$(jq -r '.changes["opa-builtins"] // false' opa_result.json)
+          opa_slf4j=$(jq -r '.changes["opa-slf4j"] // false' opa_result.json)
+
+          echo "opa-evaluator=${opa_evaluator}" >> $GITHUB_OUTPUT
+          echo "opa-jackson=${opa_jackson}" >> $GITHUB_OUTPUT
+          echo "opa-services=${opa_services}" >> $GITHUB_OUTPUT
+          echo "opa-builtins=${opa_builtins}" >> $GITHUB_OUTPUT
+          echo "opa-slf4j=${opa_slf4j}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-opa-evaluator:
+    needs: check-changes
+    if: needs.check-changes.outputs.opa-evaluator == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew :opa-evaluator:test
+
+  test-opa-jackson:
+    needs: check-changes
+    if: needs.check-changes.outputs.opa-jackson == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew :opa-jackson:test
+
+  test-opa-services:
+    needs: check-changes
+    if: needs.check-changes.outputs.opa-services == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew :opa-services:test
+
+  test-opa-builtins:
+    needs: check-changes
+    if: needs.check-changes.outputs.opa-builtins == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew :opa-builtins:test
+
+  test-opa-slf4j:
+    needs: check-changes
+    if: needs.check-changes.outputs.opa-slf4j == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew :opa-slf4j:test
+
+  pr-check-summary:
+    name: PR Check Summary
+    runs-on: ubuntu-latest
+    needs:
+      - check-changes
+      - test-opa-evaluator
+      - test-opa-jackson
+      - test-opa-services
+      - test-opa-builtins
+      - test-opa-slf4j
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download OPA
+        uses: open-policy-agent/setup-opa@v2
+        with:
+          version: latest
+
+      - name: Check job results
+        run: |
+          echo '${{ toJSON(needs) }}' > input.json
+
+          opa eval -d .github/workflows/pull-request.yml \
+            --input=input.json \
+            '{job | some _, job in data.jobs["pr-check-summary"].needs} & {job | input[job].result in {"failure", "cancelled"}}' \
+            --format=raw > failed_jobs.json
+
+          if [ "$(cat failed_jobs.json)" != "[]" ]; then
+            echo "The following required jobs did not complete successfully:"
+            jq -r '.[]' failed_jobs.json | sed 's/^/- /'
+            exit 1
+          fi
+
+          echo "All jobs completed successfully or were skipped"

--- a/tools/policy/pr-check/pr_check.rego
+++ b/tools/policy/pr-check/pr_check.rego
@@ -1,0 +1,62 @@
+package policy["pr-check"]
+
+build_change_files := [
+	"build.gradle.kts",
+	"settings.gradle.kts",
+	"gradle.properties",
+]
+
+changes["opa-evaluator"] if {
+	some changed_file in input
+	startswith(changed_file.filename, "opa-evaluator/")
+} else if {
+	some changed_file in input
+	changed_file.filename in build_change_files
+} else if {
+	some changed_file in input
+	startswith(changed_file.filename, "gradle/")
+}
+
+changes["opa-jackson"] if {
+	some changed_file in input
+	startswith(changed_file.filename, "opa-jackson/")
+} else if {
+	some changed_file in input
+	changed_file.filename in build_change_files
+} else if {
+	some changed_file in input
+	startswith(changed_file.filename, "gradle/")
+}
+
+changes["opa-services"] if {
+	some changed_file in input
+	startswith(changed_file.filename, "opa-services/")
+} else if {
+	some changed_file in input
+	changed_file.filename in build_change_files
+} else if {
+	some changed_file in input
+	startswith(changed_file.filename, "gradle/")
+}
+
+changes["opa-builtins"] if {
+	some changed_file in input
+	startswith(changed_file.filename, "opa-builtins/")
+} else if {
+	some changed_file in input
+	changed_file.filename in build_change_files
+} else if {
+	some changed_file in input
+	startswith(changed_file.filename, "gradle/")
+}
+
+changes["opa-slf4j"] if {
+	some changed_file in input
+	startswith(changed_file.filename, "opa-slf4j/")
+} else if {
+	some changed_file in input
+	changed_file.filename in build_change_files
+} else if {
+	some changed_file in input
+	startswith(changed_file.filename, "gradle/")
+}

--- a/tools/policy/pr-check/pr_check_test.rego
+++ b/tools/policy/pr-check/pr_check_test.rego
@@ -1,0 +1,88 @@
+package policy["pr-check_test"]
+
+import data.policy["pr-check"] as pr_check
+
+example_evaluator_changelist := [
+	{"filename": "opa-evaluator/src/main/java/com/example/Evaluator.java"},
+	{"filename": "opa-evaluator/build.gradle.kts"},
+]
+
+example_jackson_changelist := [
+	{"filename": "opa-jackson/src/main/java/com/example/Jackson.java"},
+]
+
+example_services_changelist := [
+	{"filename": "opa-services/src/test/java/com/example/ServiceTest.java"},
+]
+
+example_builtins_changelist := [
+	{"filename": "opa-builtins/opa-builtins-time/src/main/java/Time.java"},
+]
+
+example_slf4j_changelist := [
+	{"filename": "opa-slf4j/src/main/java/com/example/Logger.java"},
+]
+
+example_build_changelist := [
+	{"filename": "build.gradle.kts"},
+]
+
+example_gradle_changelist := [
+	{"filename": "gradle/wrapper/gradle-wrapper.properties"},
+]
+
+example_unrelated_changelist := [
+	{"filename": "README.md"},
+	{"filename": "LICENSE"},
+]
+
+test_evaluator_change_triggers_evaluator if {
+	pr_check.changes["opa-evaluator"] with input as example_evaluator_changelist
+}
+
+test_evaluator_change_does_not_trigger_others if {
+	not pr_check.changes["opa-jackson"] with input as example_evaluator_changelist
+	not pr_check.changes["opa-services"] with input as example_evaluator_changelist
+	not pr_check.changes["opa-builtins"] with input as example_evaluator_changelist
+	not pr_check.changes["opa-slf4j"] with input as example_evaluator_changelist
+}
+
+test_jackson_change_triggers_jackson if {
+	pr_check.changes["opa-jackson"] with input as example_jackson_changelist
+}
+
+test_services_change_triggers_services if {
+	pr_check.changes["opa-services"] with input as example_services_changelist
+}
+
+test_builtins_change_triggers_builtins if {
+	pr_check.changes["opa-builtins"] with input as example_builtins_changelist
+}
+
+test_slf4j_change_triggers_slf4j if {
+	pr_check.changes["opa-slf4j"] with input as example_slf4j_changelist
+}
+
+test_build_file_triggers_all if {
+	pr_check.changes["opa-evaluator"] with input as example_build_changelist
+	pr_check.changes["opa-jackson"] with input as example_build_changelist
+	pr_check.changes["opa-services"] with input as example_build_changelist
+	pr_check.changes["opa-builtins"] with input as example_build_changelist
+	pr_check.changes["opa-slf4j"] with input as example_build_changelist
+}
+
+test_gradle_dir_triggers_all if {
+	pr_check.changes["opa-evaluator"] with input as example_gradle_changelist
+	pr_check.changes["opa-jackson"] with input as example_gradle_changelist
+	pr_check.changes["opa-services"] with input as example_gradle_changelist
+	pr_check.changes["opa-builtins"] with input as example_gradle_changelist
+	pr_check.changes["opa-slf4j"] with input as example_gradle_changelist
+}
+
+test_unrelated_change_triggers_none if {
+	not pr_check.changes["opa-evaluator"] with input as example_unrelated_changelist
+	not pr_check.changes["opa-jackson"] with input as example_unrelated_changelist
+	not pr_check.changes["opa-services"] with input as example_unrelated_changelist
+	not pr_check.changes["opa-builtins"] with input as example_unrelated_changelist
+	not pr_check.changes["opa-slf4j"] with input as example_unrelated_changelist
+}


### PR DESCRIPTION
Related to: https://github.com/open-policy-agent/java-opa-sdk/issues/4
will add linting in a separate PR, this just runs the unit tests for each package depending where the files changed.

Same as how opa checks file changed using rego: https://github.com/open-policy-agent/opa/blob/main/build/policy/pr-check/pr_check.rego

and has a pr-check-summary job that is required that enforces if the required jobs have run: https://github.com/open-policy-agent/opa/blob/main/.github/workflows/pull-request.yaml#L644

