### PR TITLE
fix Maven Central publish: pin Jackson deps via jackson-bom

### DIFF
--- a/opa-builtins/opa-builtins-json/build.gradle.kts
+++ b/opa-builtins/opa-builtins-json/build.gradle.kts
@@ -11,7 +11,8 @@ dependencies {
 
     implementation("com.github.java-json-tools:json-patch:1.13")
     implementation("com.networknt:json-schema-validator:1.5.5")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.0")
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.17.0"))
+    implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     // RegoValueModule (auto-registered via Jackson SPI) provides (de)serializers for the AST

--- a/opa-services/build.gradle.kts
+++ b/opa-services/build.gradle.kts
@@ -9,7 +9,8 @@ repositories {
 dependencies {
     api(project(":opa-evaluator"))
 
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.0")
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.17.0"))
+    implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("org.apache.commons:commons-compress:1.28.0")


### PR DESCRIPTION
opa-services and opa-builtins-json declared jackson-dataformat-yaml and jackson-datatype-jsr310 without versions, producing POMs that Central Portal rejected. Import jackson-bom:2.17.0 so versions are managed in one place.

```
pkg:maven/io.github.open-policy-agent/opa-builtins-json@0.1.0
Error: Dependency version information is missing for dependency: com.fasterxml.jackson.dataformat:jackson-dataformat-yaml
Error: Dependency version information is missing for dependency: com.fasterxml.jackson.datatype:jackson-datatype-jsr310

pkg:maven/io.github.open-policy-agent/opa-services@0.1.0
Error: Dependency version information is missing for dependency: com.fasterxml.jackson.dataformat:jackson-dataformat-yaml
Error: Dependency version information is missing for dependency: com.fasterxml.jackson.datatype:jackson-datatype-jsr310
```
