### PR TITLE
fix: rename Metrics.Clear to clear

### DIFF
--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/Metrics.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/Metrics.java
@@ -18,7 +18,7 @@ public interface Metrics {
 
   Map<String, Metric> all();
 
-  void Clear();
+  void clear();
 
   interface Metric {
     // TODO: Lift out some common things here?

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/NoOpMetrics.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/NoOpMetrics.java
@@ -40,7 +40,7 @@ public class NoOpMetrics implements Metrics {
   }
 
   @Override
-  public void Clear() {
+  public void clear() {
     // No-op
   }
 

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/SimpleMetrics.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/SimpleMetrics.java
@@ -55,5 +55,7 @@ public class SimpleMetrics implements Metrics {
   }
 
   @Override
-  public void Clear() {}
+  public void clear() {
+    timers.clear();
+  }
 }

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/MetricsIntegrationTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/MetricsIntegrationTest.java
@@ -147,4 +147,20 @@ class MetricsIntegrationTest {
     // duplicate keys.
     assertEquals(firstKeys, metrics.all().keySet());
   }
+
+  @Test
+  void simpleMetricsClearRemovesRecordedTimers() throws IOException {
+    Engine engine = buildEngine("{}");
+    SimpleMetrics metrics = new SimpleMetrics();
+    Engine.PreparedQuery pq =
+            engine.prepareForEvaluation().withMetrics(metrics).build();
+
+    pq.eval(input("alice"), Boolean.class);
+
+    assertFalse(metrics.all().isEmpty(), "expected metrics to be recorded before clear");
+
+    metrics.clear();
+
+    assertTrue(metrics.all().isEmpty(), "expected metrics to be empty after clear");
+  }
 }

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/MetricsPrinterTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/MetricsPrinterTest.java
@@ -152,7 +152,7 @@ class MetricsPrinterTest {
       }
 
       @Override
-      public void Clear() {}
+      public void clear() {}
     };
   }
 


### PR DESCRIPTION
Renames `Metrics.Clear()` to `clear()` and updates implementations/usages.

Also updates `SimpleMetrics.clear()` to reset recorded timers and adds a test covering that behavior.

Fixes #55

Validation:
- [x] `./gradlew.bat :opa-evaluator:test --tests "io.github.open_policy_agent.opa.metrics.MetricsIntegrationTest" --tests "io.github.open_policy_agent.opa.metrics.MetricsPrinterTest"`