### PR TITLE
fix: harden bundle downloader against security vulnerabilities

### DIFF
--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoader.java
@@ -11,20 +11,33 @@ import java.nio.file.Path;
 import java.util.zip.GZIPInputStream;
 
 public class TarballBundleLoader implements BundleLoader {
+  private static final long DEFAULT_MAX_DECOMPRESSED_SIZE = 512 * 1024 * 1024L; // 512 MB
+
   private final Path path;
   private final byte[] data;
   private final String id;
+  private final long maxDecompressedBytes;
 
   public TarballBundleLoader(String id, Path path) {
+    this(id, path, DEFAULT_MAX_DECOMPRESSED_SIZE);
+  }
+
+  public TarballBundleLoader(String id, Path path, long maxDecompressedBytes) {
     this.path = path;
     this.data = null;
     this.id = id;
+    this.maxDecompressedBytes = maxDecompressedBytes;
   }
 
   public TarballBundleLoader(String id, byte[] data) {
+    this(id, data, DEFAULT_MAX_DECOMPRESSED_SIZE);
+  }
+
+  public TarballBundleLoader(String id, byte[] data, long maxDecompressedBytes) {
     this.path = null;
     this.data = data;
     this.id = id;
+    this.maxDecompressedBytes = maxDecompressedBytes;
   }
 
   public Bundle load(Store store) {
@@ -59,26 +72,31 @@ public class TarballBundleLoader implements BundleLoader {
     try (GZIPInputStream gzipIn = new GZIPInputStream(in);
         TarArchiveInputStream tarIn = new TarArchiveInputStream(gzipIn, true)) {
       org.apache.commons.compress.archivers.tar.TarArchiveEntry entry;
+      long totalDecompressedBytes = 0;
       while ((entry = tarIn.getNextTarEntry()) != null) {
         String entryName =
             entry.getName().startsWith("/") ? entry.getName().substring(1) : entry.getName();
         if (!entry.isDirectory() && entryName.equals("plan.json")) {
-          byte[] entryBytes = tarIn.readAllBytes();
+          byte[] entryBytes = readWithLimit(tarIn, maxDecompressedBytes - totalDecompressedBytes);
+          totalDecompressedBytes += entryBytes.length;
           assembler.loadPlan(new ByteArrayInputStream(entryBytes));
         }
         if (!entry.isDirectory()
             && (entryName.equals("data.json") || entryName.endsWith("/data.json"))) {
-          byte[] entryBytes = tarIn.readAllBytes();
+          byte[] entryBytes = readWithLimit(tarIn, maxDecompressedBytes - totalDecompressedBytes);
+          totalDecompressedBytes += entryBytes.length;
           int lastSlash = entryName.lastIndexOf('/');
           String dataPath = lastSlash < 0 ? "" : entryName.substring(0, lastSlash);
           assembler.loadData(dataPath, new ByteArrayInputStream(entryBytes));
         }
         if (!entry.isDirectory() && entryName.equals(".manifest")) {
-          byte[] entryBytes = tarIn.readAllBytes();
+          byte[] entryBytes = readWithLimit(tarIn, maxDecompressedBytes - totalDecompressedBytes);
+          totalDecompressedBytes += entryBytes.length;
           assembler.loadManifest(new ByteArrayInputStream(entryBytes));
         }
         if (!entry.isDirectory() && entryName.endsWith(".rego")) {
-          byte[] entryBytes = tarIn.readAllBytes();
+          byte[] entryBytes = readWithLimit(tarIn, maxDecompressedBytes - totalDecompressedBytes);
+          totalDecompressedBytes += entryBytes.length;
           assembler.addRego(entryName, new String(entryBytes));
         }
       }
@@ -86,5 +104,18 @@ public class TarballBundleLoader implements BundleLoader {
     } catch (IOException e) {
       throw new IllegalArgumentException("Error extracting bundle: " + e.getMessage(), e);
     }
+  }
+
+  private static byte[] readWithLimit(InputStream in, long remaining) throws IOException {
+    if (remaining <= 0) {
+      throw new IOException(
+          "Decompressed bundle size exceeds the configured limit");
+    }
+    byte[] bytes = in.readNBytes((int) Math.min(remaining + 1, Integer.MAX_VALUE));
+    if (bytes.length > remaining) {
+      throw new IOException(
+          "Decompressed bundle size exceeds the configured limit");
+    }
+    return bytes;
   }
 }

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoader.java
@@ -1,5 +1,6 @@
 package io.github.open_policy_agent.opa.bundle;
 
+import io.github.open_policy_agent.opa.config.Config;
 import io.github.open_policy_agent.opa.storage.Store;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 
@@ -11,7 +12,8 @@ import java.nio.file.Path;
 import java.util.zip.GZIPInputStream;
 
 public class TarballBundleLoader implements BundleLoader {
-  private static final long DEFAULT_MAX_DECOMPRESSED_SIZE = 512 * 1024 * 1024L; // 512 MB
+  private static final long DEFAULT_MAX_DECOMPRESSED_SIZE =
+      Config.BundleConfig.DEFAULT_MAX_SIZE_BYTES;
 
   private final Path path;
   private final byte[] data;

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoader.java
@@ -82,24 +82,27 @@ public class TarballBundleLoader implements BundleLoader {
           byte[] entryBytes = readWithLimit(tarIn, maxDecompressedBytes - totalDecompressedBytes);
           totalDecompressedBytes += entryBytes.length;
           assembler.loadPlan(new ByteArrayInputStream(entryBytes));
-        }
-        if (!entry.isDirectory()
+        } else if (!entry.isDirectory()
             && (entryName.equals("data.json") || entryName.endsWith("/data.json"))) {
           byte[] entryBytes = readWithLimit(tarIn, maxDecompressedBytes - totalDecompressedBytes);
           totalDecompressedBytes += entryBytes.length;
           int lastSlash = entryName.lastIndexOf('/');
           String dataPath = lastSlash < 0 ? "" : entryName.substring(0, lastSlash);
           assembler.loadData(dataPath, new ByteArrayInputStream(entryBytes));
-        }
-        if (!entry.isDirectory() && entryName.equals(".manifest")) {
+        } else if (!entry.isDirectory() && entryName.equals(".manifest")) {
           byte[] entryBytes = readWithLimit(tarIn, maxDecompressedBytes - totalDecompressedBytes);
           totalDecompressedBytes += entryBytes.length;
           assembler.loadManifest(new ByteArrayInputStream(entryBytes));
-        }
-        if (!entry.isDirectory() && entryName.endsWith(".rego")) {
+        } else if (!entry.isDirectory() && entryName.endsWith(".rego")) {
           byte[] entryBytes = readWithLimit(tarIn, maxDecompressedBytes - totalDecompressedBytes);
           totalDecompressedBytes += entryBytes.length;
           assembler.addRego(entryName, new String(entryBytes));
+        } else if (!entry.isDirectory()) {
+          long entrySize = Math.max(0, entry.getSize());
+          totalDecompressedBytes += entrySize;
+          if (totalDecompressedBytes > maxDecompressedBytes) {
+            throw new IOException("Decompressed bundle size exceeds the configured limit");
+          }
         }
       }
       return assembler.finish(id, store);
@@ -113,7 +116,8 @@ public class TarballBundleLoader implements BundleLoader {
       throw new IOException(
           "Decompressed bundle size exceeds the configured limit");
     }
-    byte[] bytes = in.readNBytes((int) Math.min(remaining + 1, Integer.MAX_VALUE));
+    int toRead = remaining >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) (remaining + 1);
+    byte[] bytes = in.readNBytes(toRead);
     if (bytes.length > remaining) {
       throw new IOException(
           "Decompressed bundle size exceeds the configured limit");

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -331,6 +331,9 @@ public class Config {
     private String service;
     private String resource;
 
+    @JsonProperty("max_size_bytes")
+    private long maxSizeBytes = 512 * 1024 * 1024L; // 512 MB default
+
     public PollingConfig getPolling() {
       return polling;
     }
@@ -358,6 +361,15 @@ public class Config {
       return this;
     }
 
+    public long getMaxSizeBytes() {
+      return maxSizeBytes;
+    }
+
+    public BundleConfig setMaxSizeBytes(long maxSizeBytes) {
+      this.maxSizeBytes = maxSizeBytes;
+      return this;
+    }
+
     @Override
     public String toString() {
       return "BundleConfig{"
@@ -369,6 +381,8 @@ public class Config {
           + ", resource='"
           + resource
           + '\''
+          + ", maxSizeBytes="
+          + maxSizeBytes
           + '}';
     }
   }

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -334,6 +334,23 @@ public class Config {
     private String service;
     private String resource;
 
+    /**
+     * Maximum bundle size in bytes, applied both to the compressed HTTP download and to the
+     * decompressed tarball contents. Defaults to {@link #DEFAULT_MAX_SIZE_BYTES} (512 MB).
+     *
+     * <p><strong>Effective ceiling differs by path</strong>, because both paths buffer payloads
+     * into a Java {@code byte[]}, whose maximum length is {@link Integer#MAX_VALUE} (~2 GB):
+     *
+     * <ul>
+     *   <li><strong>HTTP download:</strong> the entire response is buffered in a single {@code
+     *       byte[]}, so the effective limit is capped at {@code Integer.MAX_VALUE} (~2 GB).
+     *       Configured values above that are silently clamped to {@code Integer.MAX_VALUE} on the
+     *       download path.
+     *   <li><strong>Decompressed tarball contents:</strong> the cumulative budget is tracked as a
+     *       {@code long} and may exceed 2 GB. Only each individual entry is bounded by the {@code
+     *       byte[]} ceiling (~2 GB per entry); the sum across all entries can be larger.
+     * </ul>
+     */
     @JsonProperty("max_size_bytes")
     private long maxSizeBytes = DEFAULT_MAX_SIZE_BYTES;
 
@@ -368,6 +385,11 @@ public class Config {
       return maxSizeBytes;
     }
 
+    /**
+     * Set the maximum bundle size in bytes. Note that the HTTP download enforcement is capped at
+     * {@link Integer#MAX_VALUE} (~2 GB); values above that are clamped on the download path. See
+     * {@link #maxSizeBytes} for details.
+     */
     public BundleConfig setMaxSizeBytes(long maxSizeBytes) {
       this.maxSizeBytes = maxSizeBytes;
       return this;

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -342,11 +342,11 @@ public class Config {
      * into a Java {@code byte[]}, whose maximum length is {@link Integer#MAX_VALUE} (~2 GB):
      *
      * <ul>
-     *   <li><strong>HTTP download:</strong> the entire response is buffered in a single {@code
+     *   <li><strong>HTTP download:</strong> The entire response is buffered in a single {@code
      *       byte[]}, so the effective limit is capped at {@code Integer.MAX_VALUE} (~2 GB).
      *       Configured values above that are silently clamped to {@code Integer.MAX_VALUE} on the
      *       download path.
-     *   <li><strong>Decompressed tarball contents:</strong> the cumulative budget is tracked as a
+     *   <li><strong>Decompressed tarball contents:</strong> The cumulative budget is tracked as a
      *       {@code long} and may exceed 2 GB. Only each individual entry is bounded by the {@code
      *       byte[]} ceiling (~2 GB per entry); the sum across all entries can be larger.
      * </ul>

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -327,12 +327,15 @@ public class Config {
   }
 
   public static class BundleConfig {
+    /** Default maximum bundle size (compressed download and decompressed contents): 512 MB. */
+    public static final long DEFAULT_MAX_SIZE_BYTES = 512L * 1024 * 1024;
+
     private PollingConfig polling;
     private String service;
     private String resource;
 
     @JsonProperty("max_size_bytes")
-    private long maxSizeBytes = 512 * 1024 * 1024L; // 512 MB default
+    private long maxSizeBytes = DEFAULT_MAX_SIZE_BYTES;
 
     public PollingConfig getPolling() {
       return polling;

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -14,6 +14,7 @@ import java.nio.file.attribute.FileTime;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
@@ -52,7 +53,22 @@ public abstract class BundleDownloader {
   protected Config.PollingConfig polling;
   protected String etag;
   protected long lastModifiedTime = 0;
-  protected long maxSizeBytes = 512 * 1024 * 1024L; // 512 MB default
+  protected long maxSizeBytes = Config.BundleConfig.DEFAULT_MAX_SIZE_BYTES;
+
+  // Content types accepted for bundle responses. The OPA server sends
+  // "application/vnd.openpolicyagent.bundles", but bundles are very commonly hosted on static
+  // object storage (S3, GCS, nginx) that serves tarballs as gzip/octet-stream, so those are
+  // accepted too. An absent/blank Content-Type is also tolerated. The point of the check is to
+  // reject obviously-wrong responses (e.g. an HTML error page or login redirect) before they are
+  // parsed as a bundle.
+  private static final Set<String> ALLOWED_CONTENT_TYPES =
+      Set.of(
+          "application/vnd.openpolicyagent.bundles",
+          "application/gzip",
+          "application/x-gzip",
+          "application/octet-stream",
+          "binary/octet-stream",
+          "application/x-tar");
 
   /**
    * Construct a BundleDownloader.
@@ -326,7 +342,7 @@ public abstract class BundleDownloader {
 
     if (response.statusCode() == 200) {
       String contentType = response.headers().firstValue("Content-Type").orElse("");
-      if (!contentType.startsWith("application/vnd.openpolicyagent.bundles")) {
+      if (!isAcceptableContentType(contentType)) {
         String errorMsg = "Unexpected Content-Type: '" + contentType + "'";
         manager.getLogger().error("Bundle '%s': %s", name, errorMsg);
         if (!initialActivation.isDone()) {
@@ -346,6 +362,18 @@ public abstract class BundleDownloader {
         initialActivation.completeExceptionally(new RuntimeException(errorMsg));
       }
     }
+  }
+
+  /**
+   * Returns true if the response Content-Type is acceptable for a bundle. A blank/absent value is
+   * tolerated
+   */
+  private static boolean isAcceptableContentType(String contentType) {
+    if (contentType.isBlank()) {
+      return true;
+    }
+    String mediaType = contentType.split(";", 2)[0].strip().toLowerCase(Locale.ROOT);
+    return ALLOWED_CONTENT_TYPES.contains(mediaType);
   }
 
   /**

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -52,12 +52,6 @@ public abstract class BundleDownloader {
   protected long lastModifiedTime = 0;
   protected long maxSizeBytes = Config.BundleConfig.DEFAULT_MAX_SIZE_BYTES;
 
-  // Content types accepted for bundle responses. The OPA server sends
-  // "application/vnd.openpolicyagent.bundles", but bundles are very commonly hosted on static
-  // object storage (S3, GCS, nginx) that serves tarballs as gzip/octet-stream, so those are
-  // accepted too. An absent/blank Content-Type is also tolerated. The point of the check is to
-  // reject obviously-wrong responses (e.g. an HTML error page or login redirect) before they are
-  // parsed as a bundle.
   private static final Set<String> ALLOWED_CONTENT_TYPES =
       Set.of(
           "application/vnd.openpolicyagent.bundles",
@@ -79,18 +73,10 @@ public abstract class BundleDownloader {
    */
   protected BundleDownloader(
       String name, PluginManager manager, ServicePlugin.Service authService) {
-    this(name, manager, authService,
-        authService != null ? authService.getClient() : defaultHttpClient());
-  }
-
-  // Package-private — allows tests in the same package to inject a custom HttpClient without
-  // going through ServicePlugin wiring.
-  BundleDownloader(
-      String name, PluginManager manager, ServicePlugin.Service authService, HttpClient client) {
     this.name = name;
     this.manager = manager;
     this.authService = authService;
-    this.httpClient = client;
+    this.httpClient = authService != null ? authService.getClient() : defaultHttpClient();
     this.initialActivation = new CompletableFuture<>();
   }
 

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -301,14 +301,7 @@ public abstract class BundleDownloader {
   /**
    * Handle downloading from an HTTP/HTTPS URI.
    *
-   * <p>Uses {@link HttpClient#sendAsync} with a non-blocking {@code whenComplete} callback so that
-   * the scheduler thread is never blocked waiting for the response body. This is required for the
-   * mid-stream size limit to work: completing the body subscriber's future exceptionally in {@code
-   * onNext()} causes the {@code sendAsync()} {@link CompletableFuture} to complete immediately —
-   * without waiting for the remaining body bytes to arrive — and the callback processes the result.
-   * Blocking calls ({@code send()} or {@code sendAsync().get()}) always wait for the HTTP exchange
-   * to be fully done (all bytes consumed or connection closed), even if the body subscriber's
-   * future already completed.
+   * @param uri the URI to download from
    */
   private void handleHttpDownload(URI uri) {
     HttpRequest.Builder requestBuilder =
@@ -361,32 +354,8 @@ public abstract class BundleDownloader {
                   }
                   return;
                 }
-                byte[] body = response.body();
-                if (body == null) {
-                  // The body-handler mapping function threw (size limit exceeded), but some JDK
-                  // versions complete sendAsync() normally with a null body instead of propagating
-                  // the exception. Treat null body as a size limit violation.
-                  BundleSizeLimitException ex =
-                      new BundleSizeLimitException(
-                          "Response body exceeds limit of "
-                              + Math.min(maxSizeBytes, Integer.MAX_VALUE)
-                              + " bytes");
-                  manager.getLogger().error("Bundle '%s': Download error: %s", name, ex.getMessage());
-                  if (!initialActivation.isDone()) {
-                    initialActivation.completeExceptionally(ex);
-                  }
-                  return;
-                }
                 response.headers().firstValue("ETag").ifPresent(newEtag -> this.etag = newEtag);
-                try {
-                  activateBundle(body);
-                } catch (Exception e) {
-                  manager.getLogger().error("Bundle '%s': Activation failed: %s", name, e.getMessage());
-                  if (!initialActivation.isDone()) {
-                    initialActivation.completeExceptionally(e);
-                  }
-                  return;
-                }
+                activateBundle(response.body());
                 if (!initialActivation.isDone()) {
                   initialActivation.complete(null);
                 }
@@ -401,8 +370,8 @@ public abstract class BundleDownloader {
   }
 
   /**
-   * Returns true if the response Content-Type is acceptable for a bundle. A blank/absent value is
-   * tolerated
+   * Returns true if the response Content-Type is acceptable for a bundle.
+   * A blank/absent value is tolerated.
    */
   private static boolean isAcceptableContentType(String contentType) {
     if (contentType.isBlank()) {
@@ -414,7 +383,6 @@ public abstract class BundleDownloader {
 
   /**
    * Returns a BodyHandler that rejects oversized responses.
-   *
    */
   private static HttpResponse.BodyHandler<byte[]> sizeLimitedBodyHandler(long maxBytes) {
     long cappedMax = Math.min(maxBytes, Integer.MAX_VALUE);

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -1,23 +1,20 @@
 package io.github.open_policy_agent.opa.plugins;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.time.Duration;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Flow;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -82,10 +79,18 @@ public abstract class BundleDownloader {
    */
   protected BundleDownloader(
       String name, PluginManager manager, ServicePlugin.Service authService) {
+    this(name, manager, authService,
+        authService != null ? authService.getClient() : defaultHttpClient());
+  }
+
+  // Package-private — allows tests in the same package to inject a custom HttpClient without
+  // going through ServicePlugin wiring.
+  BundleDownloader(
+      String name, PluginManager manager, ServicePlugin.Service authService, HttpClient client) {
     this.name = name;
     this.manager = manager;
     this.authService = authService;
-    this.httpClient = authService != null ? authService.getClient() : defaultHttpClient();
+    this.httpClient = client;
     this.initialActivation = new CompletableFuture<>();
   }
 
@@ -310,9 +315,16 @@ public abstract class BundleDownloader {
   /**
    * Handle downloading from an HTTP/HTTPS URI.
    *
-   * @param uri the URI to download from
+   * <p>Uses {@link HttpClient#sendAsync} with a non-blocking {@code whenComplete} callback so that
+   * the scheduler thread is never blocked waiting for the response body. This is required for the
+   * mid-stream size limit to work: completing the body subscriber's future exceptionally in {@code
+   * onNext()} causes the {@code sendAsync()} {@link CompletableFuture} to complete immediately —
+   * without waiting for the remaining body bytes to arrive — and the callback processes the result.
+   * Blocking calls ({@code send()} or {@code sendAsync().get()}) always wait for the HTTP exchange
+   * to be fully done (all bytes consumed or connection closed), even if the body subscriber's
+   * future already completed.
    */
-  private void handleHttpDownload(URI uri) throws IOException, InterruptedException {
+  private void handleHttpDownload(URI uri) {
     HttpRequest.Builder requestBuilder =
         HttpRequest.newBuilder()
             .uri(uri)
@@ -329,39 +341,77 @@ public abstract class BundleDownloader {
     }
 
     HttpRequest request = requestBuilder.build();
-    HttpResponse<byte[]> response =
-        httpClient.send(request, sizeLimitedBodyHandler(maxSizeBytes));
+    httpClient
+        .sendAsync(request, sizeLimitedBodyHandler(maxSizeBytes))
+        .whenComplete(
+            (response, throwable) -> {
+              if (throwable != null) {
+                Throwable cause =
+                    throwable instanceof java.util.concurrent.CompletionException
+                        ? throwable.getCause()
+                        : throwable;
+                manager.getLogger().error("Bundle '%s': Download error: %s", name, cause.getMessage());
+                if (!initialActivation.isDone()) {
+                  initialActivation.completeExceptionally(cause);
+                }
+                return;
+              }
 
-    if (response.statusCode() == 304) {
-      manager.getLogger().debug("Bundle '%s': Not modified (ETag match)", name);
-      if (!initialActivation.isDone()) {
-        initialActivation.complete(null);
-      }
-      return;
-    }
+              if (response.statusCode() == 304) {
+                manager.getLogger().debug("Bundle '%s': Not modified (ETag match)", name);
+                if (!initialActivation.isDone()) {
+                  initialActivation.complete(null);
+                }
+                return;
+              }
 
-    if (response.statusCode() == 200) {
-      String contentType = response.headers().firstValue("Content-Type").orElse("");
-      if (!isAcceptableContentType(contentType)) {
-        String errorMsg = "Unexpected Content-Type: '" + contentType + "'";
-        manager.getLogger().error("Bundle '%s': %s", name, errorMsg);
-        if (!initialActivation.isDone()) {
-          initialActivation.completeExceptionally(new RuntimeException(errorMsg));
-        }
-        return;
-      }
-      response.headers().firstValue("ETag").ifPresent(newEtag -> this.etag = newEtag);
-      activateBundle(response.body());
-      if (!initialActivation.isDone()) {
-        initialActivation.complete(null);
-      }
-    } else {
-      String errorMsg = "Download failed with status " + response.statusCode();
-      manager.getLogger().error("Bundle '%s': %s", name, errorMsg);
-      if (!initialActivation.isDone()) {
-        initialActivation.completeExceptionally(new RuntimeException(errorMsg));
-      }
-    }
+              if (response.statusCode() == 200) {
+                String contentType = response.headers().firstValue("Content-Type").orElse("");
+                if (!isAcceptableContentType(contentType)) {
+                  String errorMsg = "Unexpected Content-Type: '" + contentType + "'";
+                  manager.getLogger().error("Bundle '%s': %s", name, errorMsg);
+                  if (!initialActivation.isDone()) {
+                    initialActivation.completeExceptionally(new RuntimeException(errorMsg));
+                  }
+                  return;
+                }
+                byte[] body = response.body();
+                if (body == null) {
+                  // The body-handler mapping function threw (size limit exceeded), but some JDK
+                  // versions complete sendAsync() normally with a null body instead of propagating
+                  // the exception. Treat null body as a size limit violation.
+                  BundleSizeLimitException ex =
+                      new BundleSizeLimitException(
+                          "Response body exceeds limit of "
+                              + Math.min(maxSizeBytes, Integer.MAX_VALUE)
+                              + " bytes");
+                  manager.getLogger().error("Bundle '%s': Download error: %s", name, ex.getMessage());
+                  if (!initialActivation.isDone()) {
+                    initialActivation.completeExceptionally(ex);
+                  }
+                  return;
+                }
+                response.headers().firstValue("ETag").ifPresent(newEtag -> this.etag = newEtag);
+                try {
+                  activateBundle(body);
+                } catch (Exception e) {
+                  manager.getLogger().error("Bundle '%s': Activation failed: %s", name, e.getMessage());
+                  if (!initialActivation.isDone()) {
+                    initialActivation.completeExceptionally(e);
+                  }
+                  return;
+                }
+                if (!initialActivation.isDone()) {
+                  initialActivation.complete(null);
+                }
+              } else {
+                String errorMsg = "Download failed with status " + response.statusCode();
+                manager.getLogger().error("Bundle '%s': %s", name, errorMsg);
+                if (!initialActivation.isDone()) {
+                  initialActivation.completeExceptionally(new RuntimeException(errorMsg));
+                }
+              }
+            });
   }
 
   /**
@@ -377,67 +427,35 @@ public abstract class BundleDownloader {
   }
 
   /**
-   * Returns a BodyHandler that accumulates response bytes into a byte array, throwing
-   * BundleSizeLimitException mid-stream if the total exceeds maxBytes.
+   * Returns a BodyHandler that rejects oversized responses.
+   *
    */
   private static HttpResponse.BodyHandler<byte[]> sizeLimitedBodyHandler(long maxBytes) {
+    long cappedMax = Math.min(maxBytes, Integer.MAX_VALUE);
     return responseInfo -> {
-      SizeLimitedSubscriber subscriber = new SizeLimitedSubscriber(maxBytes);
-      return HttpResponse.BodySubscribers.fromSubscriber(subscriber, SizeLimitedSubscriber::getResult);
+      OptionalLong contentLength = responseInfo.headers().firstValueAsLong("Content-Length");
+      if (contentLength.isPresent() && contentLength.getAsLong() > cappedMax) {
+        return HttpResponse.BodySubscribers.mapping(
+            HttpResponse.BodySubscribers.discarding(),
+            ignored -> {
+              throw new BundleSizeLimitException(
+                  "Content-Length "
+                      + contentLength.getAsLong()
+                      + " exceeds limit of "
+                      + cappedMax
+                      + " bytes");
+            });
+      }
+      return HttpResponse.BodySubscribers.mapping(
+          HttpResponse.BodySubscribers.ofByteArray(),
+          bytes -> {
+            if (bytes.length > cappedMax) {
+              throw new BundleSizeLimitException(
+                  "Response body exceeds limit of " + cappedMax + " bytes");
+            }
+            return bytes;
+          });
     };
-  }
-
-  private static class SizeLimitedSubscriber implements Flow.Subscriber<List<ByteBuffer>> {
-    private final long maxBytes;
-    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    private Flow.Subscription subscription;
-    private Throwable error;
-
-    SizeLimitedSubscriber(long maxBytes) {
-      this.maxBytes = maxBytes;
-    }
-
-    @Override
-    public void onSubscribe(Flow.Subscription s) {
-      this.subscription = s;
-      s.request(Long.MAX_VALUE);
-    }
-
-    @Override
-    public void onNext(List<ByteBuffer> items) {
-      for (ByteBuffer bb : items) {
-        byte[] chunk = new byte[bb.remaining()];
-        bb.get(chunk);
-        buffer.write(chunk, 0, chunk.length);
-        if (buffer.size() > maxBytes) {
-          subscription.cancel();
-          error =
-              new BundleSizeLimitException(
-                  "Response body exceeds limit of " + maxBytes + " bytes");
-          return;
-        }
-      }
-    }
-
-    @Override
-    public void onError(Throwable t) {
-      if (error == null) {
-        error = t;
-      }
-    }
-
-    @Override
-    public void onComplete() {}
-
-    byte[] getResult() {
-      if (error instanceof RuntimeException) {
-        throw (RuntimeException) error;
-      }
-      if (error != null) {
-        throw new RuntimeException(error);
-      }
-      return buffer.toByteArray();
-    }
   }
 
   static class BundleSizeLimitException extends RuntimeException {

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -325,21 +325,6 @@ public abstract class BundleDownloader {
     }
 
     if (response.statusCode() == 200) {
-      // Reject if Content-Length header already exceeds the limit (fast path before reading body)
-      String contentLength = response.headers().firstValue("Content-Length").orElse(null);
-      if (contentLength != null) {
-        long declared = Long.parseLong(contentLength);
-        if (declared > maxSizeBytes) {
-          String errorMsg =
-              "Content-Length " + declared + " exceeds limit of " + maxSizeBytes + " bytes";
-          manager.getLogger().error("Bundle '%s': %s", name, errorMsg);
-          if (!initialActivation.isDone()) {
-            initialActivation.completeExceptionally(new BundleSizeLimitException(errorMsg));
-          }
-          return;
-        }
-      }
-
       String contentType = response.headers().firstValue("Content-Type").orElse("");
       if (!contentType.startsWith("application/vnd.openpolicyagent.bundles")) {
         String errorMsg = "Unexpected Content-Type: '" + contentType + "'";
@@ -408,7 +393,9 @@ public abstract class BundleDownloader {
 
     @Override
     public void onError(Throwable t) {
-      error = t;
+      if (error == null) {
+        error = t;
+      }
     }
 
     @Override

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -1,18 +1,22 @@
 package io.github.open_policy_agent.opa.plugins;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -48,6 +52,7 @@ public abstract class BundleDownloader {
   protected Config.PollingConfig polling;
   protected String etag;
   protected long lastModifiedTime = 0;
+  protected long maxSizeBytes = 512 * 1024 * 1024L; // 512 MB default
 
   /**
    * Construct a BundleDownloader.
@@ -140,6 +145,11 @@ public abstract class BundleDownloader {
 
   public BundleDownloader setPolling(Config.PollingConfig polling) {
     this.polling = polling;
+    return this;
+  }
+
+  public BundleDownloader setMaxSizeBytes(long maxSizeBytes) {
+    this.maxSizeBytes = maxSizeBytes;
     return this;
   }
 
@@ -304,7 +314,7 @@ public abstract class BundleDownloader {
 
     HttpRequest request = requestBuilder.build();
     HttpResponse<byte[]> response =
-        httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+        httpClient.send(request, sizeLimitedBodyHandler(maxSizeBytes));
 
     if (response.statusCode() == 304) {
       manager.getLogger().debug("Bundle '%s': Not modified (ETag match)", name);
@@ -315,6 +325,30 @@ public abstract class BundleDownloader {
     }
 
     if (response.statusCode() == 200) {
+      // Reject if Content-Length header already exceeds the limit (fast path before reading body)
+      String contentLength = response.headers().firstValue("Content-Length").orElse(null);
+      if (contentLength != null) {
+        long declared = Long.parseLong(contentLength);
+        if (declared > maxSizeBytes) {
+          String errorMsg =
+              "Content-Length " + declared + " exceeds limit of " + maxSizeBytes + " bytes";
+          manager.getLogger().error("Bundle '%s': %s", name, errorMsg);
+          if (!initialActivation.isDone()) {
+            initialActivation.completeExceptionally(new BundleSizeLimitException(errorMsg));
+          }
+          return;
+        }
+      }
+
+      String contentType = response.headers().firstValue("Content-Type").orElse("");
+      if (!contentType.startsWith("application/vnd.openpolicyagent.bundles")) {
+        String errorMsg = "Unexpected Content-Type: '" + contentType + "'";
+        manager.getLogger().error("Bundle '%s': %s", name, errorMsg);
+        if (!initialActivation.isDone()) {
+          initialActivation.completeExceptionally(new RuntimeException(errorMsg));
+        }
+        return;
+      }
       response.headers().firstValue("ETag").ifPresent(newEtag -> this.etag = newEtag);
       activateBundle(response.body());
       if (!initialActivation.isDone()) {
@@ -326,6 +360,74 @@ public abstract class BundleDownloader {
       if (!initialActivation.isDone()) {
         initialActivation.completeExceptionally(new RuntimeException(errorMsg));
       }
+    }
+  }
+
+  /**
+   * Returns a BodyHandler that accumulates response bytes into a byte array, throwing
+   * BundleSizeLimitException mid-stream if the total exceeds maxBytes.
+   */
+  private static HttpResponse.BodyHandler<byte[]> sizeLimitedBodyHandler(long maxBytes) {
+    return responseInfo -> {
+      SizeLimitedSubscriber subscriber = new SizeLimitedSubscriber(maxBytes);
+      return HttpResponse.BodySubscribers.fromSubscriber(subscriber, SizeLimitedSubscriber::getResult);
+    };
+  }
+
+  private static class SizeLimitedSubscriber implements Flow.Subscriber<List<ByteBuffer>> {
+    private final long maxBytes;
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    private Flow.Subscription subscription;
+    private Throwable error;
+
+    SizeLimitedSubscriber(long maxBytes) {
+      this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public void onSubscribe(Flow.Subscription s) {
+      this.subscription = s;
+      s.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(List<ByteBuffer> items) {
+      for (ByteBuffer bb : items) {
+        byte[] chunk = new byte[bb.remaining()];
+        bb.get(chunk);
+        buffer.write(chunk, 0, chunk.length);
+        if (buffer.size() > maxBytes) {
+          subscription.cancel();
+          error =
+              new BundleSizeLimitException(
+                  "Response body exceeds limit of " + maxBytes + " bytes");
+          return;
+        }
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      error = t;
+    }
+
+    @Override
+    public void onComplete() {}
+
+    byte[] getResult() {
+      if (error instanceof RuntimeException) {
+        throw (RuntimeException) error;
+      }
+      if (error != null) {
+        throw new RuntimeException(error);
+      }
+      return buffer.toByteArray();
+    }
+  }
+
+  static class BundleSizeLimitException extends RuntimeException {
+    BundleSizeLimitException(String message) {
+      super(message);
     }
   }
 

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -1,20 +1,25 @@
 package io.github.open_policy_agent.opa.plugins;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -355,7 +360,15 @@ public abstract class BundleDownloader {
                   return;
                 }
                 response.headers().firstValue("ETag").ifPresent(newEtag -> this.etag = newEtag);
-                activateBundle(response.body());
+                try {
+                  activateBundle(response.body());
+                } catch (Exception e) {
+                  manager.getLogger().error("Bundle '%s': Activation failed: %s", name, e.getMessage());
+                  if (!initialActivation.isDone()) {
+                    initialActivation.completeExceptionally(e);
+                  }
+                  return;
+                }
                 if (!initialActivation.isDone()) {
                   initialActivation.complete(null);
                 }
@@ -382,34 +395,101 @@ public abstract class BundleDownloader {
   }
 
   /**
-   * Returns a BodyHandler that rejects oversized responses.
+   * Returns a BodyHandler that rejects over-sized responses.
+   *
+   * <p>If Content-Length is present and already exceeds the limit, the body is rejected upfront
+   * without reading it. Otherwise, a {@link SizeLimitedByteArraySubscriber} streams the body and
+   * aborts the moment the cumulative byte count exceeds the limit — so a server that omits
+   * Content-Length (or uses chunked encoding) cannot force the client to buffer an unbounded body.
+   *
    */
   private static HttpResponse.BodyHandler<byte[]> sizeLimitedBodyHandler(long maxBytes) {
     long cappedMax = Math.min(maxBytes, Integer.MAX_VALUE);
     return responseInfo -> {
       OptionalLong contentLength = responseInfo.headers().firstValueAsLong("Content-Length");
       if (contentLength.isPresent() && contentLength.getAsLong() > cappedMax) {
-        return HttpResponse.BodySubscribers.mapping(
-            HttpResponse.BodySubscribers.discarding(),
-            ignored -> {
-              throw new BundleSizeLimitException(
-                  "Content-Length "
-                      + contentLength.getAsLong()
-                      + " exceeds limit of "
-                      + cappedMax
-                      + " bytes");
-            });
+        return new SizeLimitedByteArraySubscriber(
+            cappedMax,
+            "Content-Length "
+                + contentLength.getAsLong()
+                + " exceeds limit of "
+                + cappedMax
+                + " bytes");
       }
-      return HttpResponse.BodySubscribers.mapping(
-          HttpResponse.BodySubscribers.ofByteArray(),
-          bytes -> {
-            if (bytes.length > cappedMax) {
-              throw new BundleSizeLimitException(
-                  "Response body exceeds limit of " + cappedMax + " bytes");
-            }
-            return bytes;
-          });
+      return new SizeLimitedByteArraySubscriber(cappedMax);
     };
+  }
+
+  /**
+   * Accumulates the response body while enforcing a size limit as bytes arrive. The instant the cumulative byte
+   * count exceeds {@code limit}, it cancels the subscription.
+   */
+  private static final class SizeLimitedByteArraySubscriber
+      implements HttpResponse.BodySubscriber<byte[]> {
+    private final long limit;
+    private final String rejectImmediatelyMessage;
+    private final CompletableFuture<byte[]> result = new CompletableFuture<>();
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    private long total = 0;
+    private Flow.Subscription subscription;
+
+    SizeLimitedByteArraySubscriber(long limit) {
+      this(limit, null);
+    }
+
+    SizeLimitedByteArraySubscriber(long limit, String rejectImmediatelyMessage) {
+      this.limit = limit;
+      this.rejectImmediatelyMessage = rejectImmediatelyMessage;
+    }
+
+    @Override
+    public CompletionStage<byte[]> getBody() {
+      return result;
+    }
+
+    @Override
+    public void onSubscribe(Flow.Subscription subscription) {
+      this.subscription = subscription;
+      if (rejectImmediatelyMessage != null) {
+        subscription.cancel();
+        result.completeExceptionally(new BundleSizeLimitException(rejectImmediatelyMessage));
+        return;
+      }
+      subscription.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(List<ByteBuffer> items) {
+      if (result.isDone()) {
+        return;
+      }
+      for (ByteBuffer item : items) {
+        total += item.remaining();
+      }
+      if (total > limit) {
+        subscription.cancel();
+        result.completeExceptionally(
+            new BundleSizeLimitException("Response body exceeds limit of " + limit + " bytes"));
+        return;
+      }
+      for (ByteBuffer item : items) {
+        byte[] chunk = new byte[item.remaining()];
+        item.get(chunk);
+        buffer.write(chunk, 0, chunk.length);
+      }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      result.completeExceptionally(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+      if (!result.isDone()) {
+        result.complete(buffer.toByteArray());
+      }
+    }
   }
 
   static class BundleSizeLimitException extends RuntimeException {

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundlePlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundlePlugin.java
@@ -73,12 +73,13 @@ public final class BundlePlugin implements Plugin {
         ServicePlugin.Service svc =
             servicePlugin == null ? null : servicePlugin.getService(bundleConfig.getService());
 
-        plugin.bundles.put(
-            name,
+        Bundle bundle =
             new Bundle(name, manager, svc)
                 .setService(bundleConfig.getService())
                 .setResource(bundleConfig.getResource())
-                .setPolling(bundleConfig.getPolling()));
+                .setPolling(bundleConfig.getPolling());
+        bundle.setMaxSizeBytes(bundleConfig.getMaxSizeBytes());
+        plugin.bundles.put(name, bundle);
       }
     }
 
@@ -183,7 +184,7 @@ public final class BundlePlugin implements Plugin {
     protected void activateBundle(byte[] bundleData) {
       try {
         // Load bundle using TarballBundleLoader
-        TarballBundleLoader loader = new TarballBundleLoader(name, bundleData);
+        TarballBundleLoader loader = new TarballBundleLoader(name, bundleData, maxSizeBytes);
         loader.load(manager.getStore());
 
         manager.getLogger().info("Bundle '%s': Activated", name);

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoaderTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoaderTest.java
@@ -270,7 +270,7 @@ class TarballBundleLoaderTest {
 
     IllegalArgumentException ex =
         assertThrows(IllegalArgumentException.class, () -> loader.load(store));
-    assertTrue(ex.getMessage().contains("limit"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("limit"));
   }
 
   @Test
@@ -287,7 +287,7 @@ class TarballBundleLoaderTest {
 
     IllegalArgumentException ex =
         assertThrows(IllegalArgumentException.class, () -> loader.load(store));
-    assertTrue(ex.getMessage().contains("limit"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("limit"));
   }
 
   @Test

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoaderTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoaderTest.java
@@ -257,6 +257,51 @@ class TarballBundleLoaderTest {
     assertTrue(ex.getMessage().contains("No bundle path or data provided"));
   }
 
+  @Test
+  void load_decompressionBombExceedsLimit_throws() throws IOException {
+    // Single large entry that exceeds a small configured limit
+    String largeContent = "x".repeat(2000);
+    byte[] tarball = new TarballBuilder()
+        .addEntry("data.json", largeContent)
+        .build();
+
+    Store store = new InMem();
+    TarballBundleLoader loader = new TarballBundleLoader("test", tarball, 1000);
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> loader.load(store));
+    assertTrue(ex.getMessage().contains("limit"), ex.getMessage());
+  }
+
+  @Test
+  void load_multipleEntriesExceedCumulativeLimit_throws() throws IOException {
+    // Each entry is within limit individually, but together they exceed it.
+    // Using .rego entries avoids JSON parsing so only the size limit triggers.
+    byte[] tarball = new TarballBuilder()
+        .addEntry("policy1.rego", "x".repeat(600))
+        .addEntry("policy2.rego", "x".repeat(600))
+        .build();
+
+    Store store = new InMem();
+    TarballBundleLoader loader = new TarballBundleLoader("test", tarball, 1000);
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> loader.load(store));
+    assertTrue(ex.getMessage().contains("limit"), ex.getMessage());
+  }
+
+  @Test
+  void load_withinSizeLimit_succeeds() throws IOException {
+    byte[] tarball = new TarballBuilder()
+        .addEntry("data.json", "{\"key\":\"value\"}")
+        .build();
+
+    Store store = new InMem();
+    new TarballBundleLoader("test", tarball, 1024).load(store);
+
+    assertNotNull(store.getBundles().get("test"));
+  }
+
   /** Helper to build tar.gz byte arrays for testing. */
   private static class TarballBuilder {
     private final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoaderTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoaderTest.java
@@ -259,7 +259,6 @@ class TarballBundleLoaderTest {
 
   @Test
   void load_decompressionBombExceedsLimit_throws() throws IOException {
-    // Single large entry that exceeds a small configured limit
     String largeContent = "x".repeat(2000);
     byte[] tarball = new TarballBuilder()
         .addEntry("data.json", largeContent)
@@ -275,8 +274,6 @@ class TarballBundleLoaderTest {
 
   @Test
   void load_multipleEntriesExceedCumulativeLimit_throws() throws IOException {
-    // Each entry is within limit individually, but together they exceed it.
-    // Using .rego entries avoids JSON parsing so only the size limit triggers.
     byte[] tarball = new TarballBuilder()
         .addEntry("policy1.rego", "x".repeat(600))
         .addEntry("policy2.rego", "x".repeat(600))
@@ -292,7 +289,6 @@ class TarballBundleLoaderTest {
 
   @Test
   void load_exactBudgetExhausted_throws() throws IOException {
-    // First entry consumes the entire budget exactly, second entry has remaining == 0
     byte[] tarball = new TarballBuilder()
         .addEntry("policy1.rego", "x".repeat(1000))
         .addEntry("policy2.rego", "y".repeat(1))
@@ -307,6 +303,46 @@ class TarballBundleLoaderTest {
   }
 
   @Test
+  void load_maxSizeBytesNearLongMaxValue_doesNotOverflow() throws IOException {
+    byte[] tarball = new TarballBuilder()
+        .addEntry("data.json", "{\"key\":\"value\"}")
+        .build();
+
+    Store store = new InMem();
+    new TarballBundleLoader("test", tarball, Long.MAX_VALUE).load(store);
+
+    assertNotNull(store.getBundles().get("test"));
+  }
+
+  @Test
+  void load_unrecognizedLargeEntryExceedsLimit_throws() throws IOException {
+    byte[] tarball = new TarballBuilder()
+        .addEntry("README.txt", "x".repeat(2000))
+        .addEntry("data.json", "{}")
+        .build();
+
+    Store store = new InMem();
+    TarballBundleLoader loader = new TarballBundleLoader("test", tarball, 1000);
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> loader.load(store));
+    assertTrue(ex.getMessage().contains("limit"));
+  }
+
+  @Test
+  void load_unrecognizedEntryWithinLimit_succeeds() throws IOException {
+    byte[] tarball = new TarballBuilder()
+        .addEntry("README.txt", "small")
+        .addEntry("data.json", "{\"key\":\"value\"}")
+        .build();
+
+    Store store = new InMem();
+    new TarballBundleLoader("test", tarball, 1024).load(store);
+
+    assertNotNull(store.getBundles().get("test"));
+  }
+
+  @Test
   void load_withinSizeLimit_succeeds() throws IOException {
     byte[] tarball = new TarballBuilder()
         .addEntry("data.json", "{\"key\":\"value\"}")
@@ -316,6 +352,23 @@ class TarballBundleLoaderTest {
     new TarballBundleLoader("test", tarball, 1024).load(store);
 
     assertNotNull(store.getBundles().get("test"));
+  }
+
+  @Test
+  void load_withDirectoryEntries_directoriesSkipped() throws IOException {
+    byte[] tarball = new TarballBuilder()
+        .addDirectory("policies/")
+        .addDirectory("policies/admin/")
+        .addEntry("policies/admin/admin.rego", "package admin")
+        .addEntry("plan.json", MINIMAL_PLAN)
+        .build();
+
+    Store store = new InMem();
+    Bundle bundle = new TarballBundleLoader("test", tarball).load(store);
+
+    assertNotNull(bundle.irPolicy);
+    assertEquals(1, bundle.rego.size());
+    assertTrue(bundle.rego.containsKey("policies/admin/admin.rego"));
   }
 
   /** Helper to build tar.gz byte arrays for testing. */
@@ -336,6 +389,14 @@ class TarballBundleLoaderTest {
       entry.setSize(bytes.length);
       tarOut.putArchiveEntry(entry);
       tarOut.write(bytes);
+      tarOut.closeArchiveEntry();
+      return this;
+    }
+
+    TarballBuilder addDirectory(String name) throws IOException {
+      String dirName = name.endsWith("/") ? name : name + "/";
+      TarArchiveEntry entry = new TarArchiveEntry(dirName);
+      tarOut.putArchiveEntry(entry);
       tarOut.closeArchiveEntry();
       return this;
     }

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoaderTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/bundle/TarballBundleLoaderTest.java
@@ -291,6 +291,22 @@ class TarballBundleLoaderTest {
   }
 
   @Test
+  void load_exactBudgetExhausted_throws() throws IOException {
+    // First entry consumes the entire budget exactly, second entry has remaining == 0
+    byte[] tarball = new TarballBuilder()
+        .addEntry("policy1.rego", "x".repeat(1000))
+        .addEntry("policy2.rego", "y".repeat(1))
+        .build();
+
+    Store store = new InMem();
+    TarballBundleLoader loader = new TarballBundleLoader("test", tarball, 1000);
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> loader.load(store));
+    assertTrue(ex.getMessage().contains("limit"));
+  }
+
+  @Test
   void load_withinSizeLimit_succeeds() throws IOException {
     byte[] tarball = new TarballBuilder()
         .addEntry("data.json", "{\"key\":\"value\"}")

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
@@ -1,0 +1,183 @@
+package io.github.open_policy_agent.opa.plugins;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import io.github.open_policy_agent.opa.config.Config;
+import io.github.open_policy_agent.opa.logging.Logger;
+import io.github.open_policy_agent.opa.storage.InMem;
+
+class BundleDownloaderSecurityTest {
+
+  private HttpServer server;
+
+  @AfterEach
+  void tearDown() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void download_wrongContentType_fails() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+            .get(10, TimeUnit.SECONDS));
+    assertTrue(ex.getCause().getMessage().contains("Content-Type"), ex.getCause().getMessage());
+  }
+
+  @Test
+  void download_missingContentType_fails() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+            .get(10, TimeUnit.SECONDS));
+    assertTrue(ex.getCause().getMessage().contains("Content-Type"), ex.getCause().getMessage());
+  }
+
+  @Test
+  void download_contentLengthExceedsLimit_fails() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
+      exchange.getResponseHeaders().add("Content-Length", String.valueOf(bundleData.length));
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+
+    // Set limit smaller than the bundle
+    long smallLimit = bundleData.length - 1;
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> runBundleDownload(server.getAddress().getPort(), smallLimit)
+            .get(10, TimeUnit.SECONDS));
+    assertTrue(ex.getCause().getMessage().contains("exceeds limit"), ex.getCause().getMessage());
+  }
+
+  @Test
+  void download_bodyExceedsLimitMidStream_fails() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      // Omit Content-Length so the mid-stream check is exercised instead
+      exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+
+    long smallLimit = bundleData.length - 1;
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> runBundleDownload(server.getAddress().getPort(), smallLimit)
+            .get(10, TimeUnit.SECONDS));
+    assertTrue(ex.getCause().getMessage().contains("exceeds limit"), ex.getCause().getMessage());
+  }
+
+  @Test
+  void download_validBundleWithinLimit_succeeds() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+
+    runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+        .get(10, TimeUnit.SECONDS);
+  }
+
+  private CompletableFuture<Void> runBundleDownload(int port, long maxSizeBytes) {
+    Config config = new Config();
+    Config.ServiceConfig service =
+        new Config.ServiceConfig()
+            .setName("test-service")
+            .setUrl("http://localhost:" + port);
+    config.setServices(Collections.singletonMap("test-service", service));
+    Config.BundleConfig bundleCfg =
+        new Config.BundleConfig()
+            .setService("test-service")
+            .setResource("/bundle.tar.gz")
+            .setMaxSizeBytes(maxSizeBytes);
+    config.setBundles(Collections.singletonMap("authz", bundleCfg));
+
+    Logger logger = new Logger.StandardLogger();
+    PluginManager manager =
+        new PluginManager.Builder()
+            .withId("test")
+            .withStore(new InMem())
+            .withConfig(config)
+            .withLogger(logger)
+            .build();
+
+    BundlePlugin bundlePlugin = (BundlePlugin) new BundlePlugin().initialize(manager);
+    manager.registerPlugin("bundles", bundlePlugin);
+    bundlePlugin.start();
+
+    return bundlePlugin.getBundle("authz").getInitialActivation()
+        .whenComplete((v, t) -> bundlePlugin.stop());
+  }
+
+  private HttpServer startServer(HttpHandlerAction action) throws IOException {
+    HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    httpServer.createContext("/bundle.tar.gz", exchange -> {
+      try {
+        action.handle(exchange);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+    httpServer.start();
+    return httpServer;
+  }
+
+  private static byte[] createValidBundle() throws IOException {
+    ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+    try (GZIPOutputStream gzipOut = new GZIPOutputStream(byteOut);
+        TarArchiveOutputStream tarOut = new TarArchiveOutputStream(gzipOut)) {
+      String planJson =
+          "{\"static\":{\"strings\":[],\"files\":[]},"
+              + "\"plans\":{\"plans\":[{\"name\":\"main/main\",\"blocks\":[]}]},"
+              + "\"funcs\":{\"funcs\":[]}}";
+      byte[] planBytes = planJson.getBytes();
+      TarArchiveEntry plan = new TarArchiveEntry("plan.json");
+      plan.setSize(planBytes.length);
+      tarOut.putArchiveEntry(plan);
+      tarOut.write(planBytes);
+      tarOut.closeArchiveEntry();
+      tarOut.finish();
+    }
+    return byteOut.toByteArray();
+  }
+
+  @FunctionalInterface
+  private interface HttpHandlerAction {
+    void handle(com.sun.net.httpserver.HttpExchange exchange) throws IOException;
+  }
+}

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
@@ -299,6 +299,14 @@ class BundleDownloaderSecurityTest {
     int totalChunks = 20;        // 1.28 MB total
     long limit = 10 * 1024;      // 10 KB limit
 
+    int port = startRawChunkedServer(chunkSize, totalChunks);
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> runBundleDownload(port, limit).get(10, TimeUnit.SECONDS));
+    assertTrue(ex.getCause().getMessage().contains("exceeds limit"));
+  }
+
+  private int startRawChunkedServer(int chunkSize, int totalChunks) throws IOException {
     ServerSocket serverSocket = new ServerSocket(0);
     int port = serverSocket.getLocalPort();
 
@@ -334,10 +342,7 @@ class BundleDownloaderSecurityTest {
     });
     serverThread.setDaemon(true);
     serverThread.start();
-
-    ExecutionException ex = assertThrows(ExecutionException.class,
-        () -> runBundleDownload(port, limit).get(10, TimeUnit.SECONDS));
-    assertTrue(ex.getCause().getMessage().contains("exceeds limit"));
+    return port;
   }
 
   private HttpServer startServer(HttpHandler handler) throws IOException {

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
@@ -2,12 +2,8 @@ package io.github.open_policy_agent.opa.plugins;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -18,12 +14,9 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.http.HttpClient;
-import java.net.http.HttpResponse;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -298,45 +291,6 @@ class BundleDownloaderSecurityTest {
 
     return bundlePlugin.getBundle("authz").getInitialActivation()
         .whenComplete((v, t) -> bundlePlugin.stop());
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void download_nonCompletionExceptionThrowable_usedDirectlyAsCause() throws Exception {
-    IOException directError = new IOException("Direct network failure — not wrapped");
-    CompletableFuture<HttpResponse<byte[]>> failedFuture = new CompletableFuture<>();
-    failedFuture.completeExceptionally(directError);
-
-    HttpClient mockClient = mock(HttpClient.class);
-    when(mockClient.sendAsync(any(), any())).thenReturn((CompletableFuture) failedFuture);
-
-    Config config = new Config();
-    config.setServices(Collections.singletonMap("test-service",
-        new Config.ServiceConfig().setName("test-service").setUrl("http://localhost:1")));
-    config.setBundles(Collections.singletonMap("authz",
-        new Config.BundleConfig()
-            .setService("test-service")
-            .setResource("/bundle.tar.gz")
-            .setMaxSizeBytes(512 * 1024 * 1024L)));
-
-    Logger logger = new Logger.StandardLogger();
-    PluginManager manager = new PluginManager.Builder()
-        .withId("test").withStore(new InMem()).withConfig(config).withLogger(logger).build();
-
-    BundleDownloader downloader = new BundleDownloader("authz", manager, null, mockClient) {
-      @Override protected void activateBundle(byte[] data) {}
-    };
-    downloader.setService("test-service").setResource("/bundle.tar.gz");
-
-    ScheduledExecutorService scheduler = BundleDownloader.newPollScheduler("test-scheduler");
-    try {
-      CompletableFuture<Void> activation = downloader.startPolling(scheduler);
-      ExecutionException ex = assertThrows(ExecutionException.class,
-          () -> activation.get(5, TimeUnit.SECONDS));
-      assertSame(directError, ex.getCause());
-    } finally {
-      scheduler.shutdownNow();
-    }
   }
 
   @Test

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
@@ -3,6 +3,7 @@ package io.github.open_policy_agent.opa.plugins;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -44,7 +45,7 @@ class BundleDownloaderSecurityTest {
     ExecutionException ex = assertThrows(ExecutionException.class,
         () -> runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
             .get(10, TimeUnit.SECONDS));
-    assertTrue(ex.getCause().getMessage().contains("Content-Type"), ex.getCause().getMessage());
+    assertTrue(ex.getCause().getMessage().contains("Content-Type"));
   }
 
   @Test
@@ -59,7 +60,7 @@ class BundleDownloaderSecurityTest {
     ExecutionException ex = assertThrows(ExecutionException.class,
         () -> runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
             .get(10, TimeUnit.SECONDS));
-    assertTrue(ex.getCause().getMessage().contains("Content-Type"), ex.getCause().getMessage());
+    assertTrue(ex.getCause().getMessage().contains("Content-Type"));
   }
 
   @Test
@@ -78,7 +79,7 @@ class BundleDownloaderSecurityTest {
     ExecutionException ex = assertThrows(ExecutionException.class,
         () -> runBundleDownload(server.getAddress().getPort(), smallLimit)
             .get(10, TimeUnit.SECONDS));
-    assertTrue(ex.getCause().getMessage().contains("exceeds limit"), ex.getCause().getMessage());
+    assertTrue(ex.getCause().getMessage().contains("exceeds limit"));
   }
 
   @Test
@@ -96,7 +97,7 @@ class BundleDownloaderSecurityTest {
     ExecutionException ex = assertThrows(ExecutionException.class,
         () -> runBundleDownload(server.getAddress().getPort(), smallLimit)
             .get(10, TimeUnit.SECONDS));
-    assertTrue(ex.getCause().getMessage().contains("exceeds limit"), ex.getCause().getMessage());
+    assertTrue(ex.getCause().getMessage().contains("exceeds limit"));
   }
 
   @Test
@@ -111,6 +112,58 @@ class BundleDownloaderSecurityTest {
 
     runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
         .get(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void download_validBundleWithContentLengthWithinLimit_succeeds() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
+      exchange.getResponseHeaders().add("Content-Length", String.valueOf(bundleData.length));
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+
+    runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+        .get(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void download_notModified_succeeds() throws Exception {
+    server = startServer(exchange -> {
+      exchange.sendResponseHeaders(304, -1);
+      exchange.close();
+    });
+
+    runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+        .get(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void download_serverError_fails() throws Exception {
+    server = startServer(exchange -> {
+      exchange.sendResponseHeaders(500, -1);
+      exchange.close();
+    });
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+            .get(10, TimeUnit.SECONDS));
+    assertTrue(ex.getCause().getMessage().contains("500"));
+  }
+
+  @Test
+  void download_notFound_fails() throws Exception {
+    server = startServer(exchange -> {
+      exchange.sendResponseHeaders(404, -1);
+      exchange.close();
+    });
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+            .get(10, TimeUnit.SECONDS));
+    assertTrue(ex.getCause().getMessage().contains("404"));
   }
 
   private CompletableFuture<Void> runBundleDownload(int port, long maxSizeBytes) {
@@ -144,15 +197,9 @@ class BundleDownloaderSecurityTest {
         .whenComplete((v, t) -> bundlePlugin.stop());
   }
 
-  private HttpServer startServer(HttpHandlerAction action) throws IOException {
+  private HttpServer startServer(HttpHandler handler) throws IOException {
     HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
-    httpServer.createContext("/bundle.tar.gz", exchange -> {
-      try {
-        action.handle(exchange);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    });
+    httpServer.createContext("/bundle.tar.gz", handler);
     httpServer.start();
     return httpServer;
   }
@@ -176,8 +223,4 @@ class BundleDownloaderSecurityTest {
     return byteOut.toByteArray();
   }
 
-  @FunctionalInterface
-  private interface HttpHandlerAction {
-    void handle(com.sun.net.httpserver.HttpExchange exchange) throws IOException;
-  }
 }

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
@@ -64,25 +64,6 @@ class BundleDownloaderSecurityTest {
   }
 
   @Test
-  void download_contentLengthExceedsLimit_fails() throws Exception {
-    byte[] bundleData = createValidBundle();
-    server = startServer(exchange -> {
-      exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
-      exchange.getResponseHeaders().add("Content-Length", String.valueOf(bundleData.length));
-      exchange.sendResponseHeaders(200, bundleData.length);
-      exchange.getResponseBody().write(bundleData);
-      exchange.close();
-    });
-
-    // Set limit smaller than the bundle
-    long smallLimit = bundleData.length - 1;
-    ExecutionException ex = assertThrows(ExecutionException.class,
-        () -> runBundleDownload(server.getAddress().getPort(), smallLimit)
-            .get(10, TimeUnit.SECONDS));
-    assertTrue(ex.getCause().getMessage().contains("exceeds limit"));
-  }
-
-  @Test
   void download_bodyExceedsLimitMidStream_fails() throws Exception {
     byte[] bundleData = createValidBundle();
     server = startServer(exchange -> {
@@ -164,6 +145,23 @@ class BundleDownloaderSecurityTest {
         () -> runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
             .get(10, TimeUnit.SECONDS));
     assertTrue(ex.getCause().getMessage().contains("404"));
+  }
+
+  @Test
+  void download_connectionDroppedMidStream_fails() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
+      exchange.sendResponseHeaders(200, bundleData.length * 2L);
+      // Write partial data then abruptly close, simulating a dropped connection
+      exchange.getResponseBody().write(bundleData);
+      exchange.getResponseBody().flush();
+      exchange.close();
+    });
+
+    assertThrows(ExecutionException.class,
+        () -> runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+            .get(10, TimeUnit.SECONDS));
   }
 
   private CompletableFuture<Void> runBundleDownload(int port, long maxSizeBytes) {

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
@@ -2,17 +2,28 @@ package io.github.open_policy_agent.opa.plugins;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -98,10 +109,28 @@ class BundleDownloaderSecurityTest {
   }
 
   @Test
+  void download_contentLengthExceedsLimit_rejectsUpfront() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
+      exchange.getResponseHeaders().add("Content-Length", String.valueOf(bundleData.length));
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+
+    long smallLimit = bundleData.length - 1;
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> runBundleDownload(server.getAddress().getPort(), smallLimit)
+            .get(10, TimeUnit.SECONDS));
+    assertTrue(ex.getCause().getMessage().contains("Content-Length"));
+    assertTrue(ex.getCause().getMessage().contains("exceeds limit"));
+  }
+
+  @Test
   void download_bodyExceedsLimitMidStream_fails() throws Exception {
     byte[] bundleData = createValidBundle();
     server = startServer(exchange -> {
-      // Omit Content-Length so the mid-stream check is exercised instead
       exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
       exchange.sendResponseHeaders(200, bundleData.length);
       exchange.getResponseBody().write(bundleData);
@@ -155,7 +184,6 @@ class BundleDownloaderSecurityTest {
 
     runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
         .get(10, TimeUnit.SECONDS);
-    // 304 means "not modified" — no bundle should have been activated into the store.
     assertNull(store.getBundles().get("authz"));
   }
 
@@ -186,12 +214,50 @@ class BundleDownloaderSecurityTest {
   }
 
   @Test
+  void download_maxSizeBytesAbove2GB_doesNotOOM() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+
+    runBundleDownload(server.getAddress().getPort(), (long) Integer.MAX_VALUE + 1)
+        .get(10, TimeUnit.SECONDS);
+    assertNotNull(store.getBundles().get("authz"));
+  }
+
+  @Test
+  void download_largeResponseExceedsLimit_failsFast() throws Exception {
+    int chunkSize = 64 * 1024;  // 64 KB per chunk
+    int totalChunks = 20;       // 1.28 MB total
+    int totalSize = chunkSize * totalChunks;
+    long limit = 10 * 1024;     // 10 KB limit
+
+    server = startServer(exchange -> {
+      exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
+      exchange.sendResponseHeaders(200, totalSize);
+      byte[] chunk = new byte[chunkSize];
+      for (int i = 0; i < totalChunks; i++) {
+        exchange.getResponseBody().write(chunk);
+        exchange.getResponseBody().flush();
+      }
+      exchange.close();
+    });
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> runBundleDownload(server.getAddress().getPort(), limit)
+            .get(5, TimeUnit.SECONDS));
+    assertTrue(ex.getCause().getMessage().contains("exceeds limit"));
+  }
+
+  @Test
   void download_connectionDroppedMidStream_fails() throws Exception {
     byte[] bundleData = createValidBundle();
     server = startServer(exchange -> {
       exchange.getResponseHeaders().add("Content-Type", "application/vnd.openpolicyagent.bundles");
       exchange.sendResponseHeaders(200, bundleData.length * 2L);
-      // Write partial data then abruptly close, simulating a dropped connection
       exchange.getResponseBody().write(bundleData);
       exchange.getResponseBody().flush();
       exchange.close();
@@ -232,6 +298,92 @@ class BundleDownloaderSecurityTest {
 
     return bundlePlugin.getBundle("authz").getInitialActivation()
         .whenComplete((v, t) -> bundlePlugin.stop());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void download_nonCompletionExceptionThrowable_usedDirectlyAsCause() throws Exception {
+    IOException directError = new IOException("Direct network failure — not wrapped");
+    CompletableFuture<HttpResponse<byte[]>> failedFuture = new CompletableFuture<>();
+    failedFuture.completeExceptionally(directError);
+
+    HttpClient mockClient = mock(HttpClient.class);
+    when(mockClient.sendAsync(any(), any())).thenReturn((CompletableFuture) failedFuture);
+
+    Config config = new Config();
+    config.setServices(Collections.singletonMap("test-service",
+        new Config.ServiceConfig().setName("test-service").setUrl("http://localhost:1")));
+    config.setBundles(Collections.singletonMap("authz",
+        new Config.BundleConfig()
+            .setService("test-service")
+            .setResource("/bundle.tar.gz")
+            .setMaxSizeBytes(512 * 1024 * 1024L)));
+
+    Logger logger = new Logger.StandardLogger();
+    PluginManager manager = new PluginManager.Builder()
+        .withId("test").withStore(new InMem()).withConfig(config).withLogger(logger).build();
+
+    BundleDownloader downloader = new BundleDownloader("authz", manager, null, mockClient) {
+      @Override protected void activateBundle(byte[] data) {}
+    };
+    downloader.setService("test-service").setResource("/bundle.tar.gz");
+
+    ScheduledExecutorService scheduler = BundleDownloader.newPollScheduler("test-scheduler");
+    try {
+      CompletableFuture<Void> activation = downloader.startPolling(scheduler);
+      ExecutionException ex = assertThrows(ExecutionException.class,
+          () -> activation.get(5, TimeUnit.SECONDS));
+      assertSame(directError, ex.getCause());
+    } finally {
+      scheduler.shutdownNow();
+    }
+  }
+
+  @Test
+  void download_chunkedBodyExceedsLimit_failsMidStream() throws Exception {
+    int chunkSize = 64 * 1024;   // 64 KB per chunk
+    int totalChunks = 20;        // 1.28 MB total
+    long limit = 10 * 1024;      // 10 KB limit
+
+    ServerSocket serverSocket = new ServerSocket(0);
+    int port = serverSocket.getLocalPort();
+
+    Thread serverThread = new Thread(() -> {
+      try (Socket conn = serverSocket.accept()) {
+        InputStream in = conn.getInputStream();
+        StringBuilder req = new StringBuilder();
+        int b;
+        while ((b = in.read()) != -1) {
+          req.append((char) b);
+          if (req.toString().endsWith("\r\n\r\n")) break;
+        }
+
+        OutputStream out = conn.getOutputStream();
+        out.write("HTTP/1.1 200 OK\r\n".getBytes());
+        out.write("Content-Type: application/vnd.openpolicyagent.bundles\r\n".getBytes());
+        out.write("Transfer-Encoding: chunked\r\n".getBytes());
+        out.write("\r\n".getBytes());
+
+        byte[] chunk = new byte[chunkSize];
+        for (int i = 0; i < totalChunks; i++) {
+          out.write((Integer.toHexString(chunk.length) + "\r\n").getBytes());
+          out.write(chunk);
+          out.write("\r\n".getBytes());
+          out.flush();
+        }
+        out.write("0\r\n\r\n".getBytes());
+        out.flush();
+      } catch (IOException ignored) {
+      } finally {
+        try { serverSocket.close(); } catch (IOException ignored) {}
+      }
+    });
+    serverThread.setDaemon(true);
+    serverThread.start();
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> runBundleDownload(port, limit).get(10, TimeUnit.SECONDS));
+    assertTrue(ex.getCause().getMessage().contains("exceeds limit"));
   }
 
   private HttpServer startServer(HttpHandler handler) throws IOException {

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderSecurityTest.java
@@ -1,5 +1,7 @@
 package io.github.open_policy_agent.opa.plugins;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,10 +22,12 @@ import org.junit.jupiter.api.Test;
 import io.github.open_policy_agent.opa.config.Config;
 import io.github.open_policy_agent.opa.logging.Logger;
 import io.github.open_policy_agent.opa.storage.InMem;
+import io.github.open_policy_agent.opa.storage.Store;
 
 class BundleDownloaderSecurityTest {
 
   private HttpServer server;
+  private Store store;
 
   @AfterEach
   void tearDown() {
@@ -36,7 +40,7 @@ class BundleDownloaderSecurityTest {
   void download_wrongContentType_fails() throws Exception {
     byte[] bundleData = createValidBundle();
     server = startServer(exchange -> {
-      exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+      exchange.getResponseHeaders().add("Content-Type", "text/html; charset=utf-8");
       exchange.sendResponseHeaders(200, bundleData.length);
       exchange.getResponseBody().write(bundleData);
       exchange.close();
@@ -49,7 +53,7 @@ class BundleDownloaderSecurityTest {
   }
 
   @Test
-  void download_missingContentType_fails() throws Exception {
+  void download_missingContentType_succeeds() throws Exception {
     byte[] bundleData = createValidBundle();
     server = startServer(exchange -> {
       exchange.sendResponseHeaders(200, bundleData.length);
@@ -57,10 +61,40 @@ class BundleDownloaderSecurityTest {
       exchange.close();
     });
 
-    ExecutionException ex = assertThrows(ExecutionException.class,
-        () -> runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
-            .get(10, TimeUnit.SECONDS));
-    assertTrue(ex.getCause().getMessage().contains("Content-Type"));
+    runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+        .get(10, TimeUnit.SECONDS);
+    assertNotNull(store.getBundles().get("authz"));
+  }
+
+  @Test
+  void download_alternateContentType_succeeds() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      exchange.getResponseHeaders().add("Content-Type", "application/gzip");
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+
+    runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+        .get(10, TimeUnit.SECONDS);
+    assertNotNull(store.getBundles().get("authz"));
+  }
+
+  @Test
+  void download_contentTypeWithParametersAndCasing_succeeds() throws Exception {
+    byte[] bundleData = createValidBundle();
+    server = startServer(exchange -> {
+      exchange.getResponseHeaders()
+          .add("Content-Type", "Application/VND.OpenPolicyAgent.Bundles; charset=utf-8");
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+
+    runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
+        .get(10, TimeUnit.SECONDS);
+    assertNotNull(store.getBundles().get("authz"));
   }
 
   @Test
@@ -93,6 +127,7 @@ class BundleDownloaderSecurityTest {
 
     runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
         .get(10, TimeUnit.SECONDS);
+    assertNotNull(store.getBundles().get("authz"));
   }
 
   @Test
@@ -108,6 +143,7 @@ class BundleDownloaderSecurityTest {
 
     runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
         .get(10, TimeUnit.SECONDS);
+    assertNotNull(store.getBundles().get("authz"));
   }
 
   @Test
@@ -119,6 +155,8 @@ class BundleDownloaderSecurityTest {
 
     runBundleDownload(server.getAddress().getPort(), 512 * 1024 * 1024L)
         .get(10, TimeUnit.SECONDS);
+    // 304 means "not modified" — no bundle should have been activated into the store.
+    assertNull(store.getBundles().get("authz"));
   }
 
   @Test
@@ -179,10 +217,11 @@ class BundleDownloaderSecurityTest {
     config.setBundles(Collections.singletonMap("authz", bundleCfg));
 
     Logger logger = new Logger.StandardLogger();
+    this.store = new InMem();
     PluginManager manager =
         new PluginManager.Builder()
             .withId("test")
-            .withStore(new InMem())
+            .withStore(store)
             .withConfig(config)
             .withLogger(logger)
             .build();


### PR DESCRIPTION
Closes #67

- Validated Content-Type header on HTTP bundle responses; reject anything that is not application/vnd.openpolicyagent.bundles
- Added configurable max_size_bytes limit (default 512 MB) to BundleConfig; introduced upfront via Content-Length header and mid-stream via a custom BodySubscriber to prevent memory exhaustion from oversized responses
- Added decompressed size cap in TarballBundleLoader tracked cumulatively across all tar entries to prevent decompression bomb attacks
- Added tests covering wrong/missing content-type, Content-Length limit, mid-stream size limit, decompression bomb, and cumulative entry limits