### PR TITLE
fix: correct drop decision config accessor typo

### DIFF
--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -165,7 +165,7 @@ public class Config {
     private String maskDecision = "system/log/mask";
 
     @JsonProperty("drop_decision")
-    private String dropDedcision = "system/log/drop";
+    private String dropDecision = "system/log/drop";
 
     @JsonProperty("min_delay_seconds")
     private Integer minDelaySeconds = 300;
@@ -214,12 +214,12 @@ public class Config {
       return this;
     }
 
-    public String getDropDedcision() {
-      return dropDedcision;
+    public String getDropDecision() {
+      return dropDecision;
     }
 
-    public DecisionLogsConfig setDropDedcision(String dropDedcision) {
-      this.dropDedcision = dropDedcision;
+    public DecisionLogsConfig setDropDecision(String dropDecision) {
+      this.dropDecision = dropDecision;
       return this;
     }
 

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/DecisionLogPlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/DecisionLogPlugin.java
@@ -99,7 +99,7 @@ public final class DecisionLogPlugin implements Plugin {
               .setConsole(logsConfig.getConsole())
               .setService(logsConfig.getService())
               .setMaskDecision(logsConfig.getMaskDecision())
-              .setDropDecision(logsConfig.getDropDedcision())
+              .setDropDecision(logsConfig.getDropDecision())
               .setMinDelaySeconds(logsConfig.getMinDelaySeconds())
               .setResource(logsConfig.getResource())
               .setReporting(logsConfig.getReporting());

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/config/ConfigTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/config/ConfigTest.java
@@ -281,7 +281,7 @@ class ConfigTest {
 
     assertFalse(decisionLogs.getConsole());
     assertEquals("system/log/mask", decisionLogs.getMaskDecision());
-    assertEquals("system/log/drop", decisionLogs.getDropDedcision());
+    assertEquals("system/log/drop", decisionLogs.getDropDecision());
     assertEquals(300, decisionLogs.getMinDelaySeconds());
     assertEquals(600, decisionLogs.getMaxDelaySeconds());
     assertEquals("/logs", decisionLogs.getResource());

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/DecisionLogPluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/DecisionLogPluginTest.java
@@ -217,7 +217,7 @@ class DecisionLogPluginTest {
 
     assertFalse(decisionLogs.getConsole());
     assertEquals("system/log/mask", decisionLogs.getMaskDecision());
-    assertEquals("system/log/drop", decisionLogs.getDropDedcision());
+    assertEquals("system/log/drop", decisionLogs.getDropDecision());
     assertEquals(300, decisionLogs.getMinDelaySeconds());
     assertEquals(600, decisionLogs.getMaxDelaySeconds());
     assertEquals("/logs", decisionLogs.getResource());
@@ -231,7 +231,7 @@ class DecisionLogPluginTest {
             .setConsole(true)
             .setResource("/custom/logs")
             .setMaskDecision("custom/mask")
-            .setDropDedcision("custom/drop")
+            .setDropDecision("custom/drop")
             .setMinDelaySeconds(60)
             .setMaxDelaySeconds(120);
 
@@ -239,7 +239,7 @@ class DecisionLogPluginTest {
     assertTrue(decisionLogs.getConsole());
     assertEquals("/custom/logs", decisionLogs.getResource());
     assertEquals("custom/mask", decisionLogs.getMaskDecision());
-    assertEquals("custom/drop", decisionLogs.getDropDedcision());
+    assertEquals("custom/drop", decisionLogs.getDropDecision());
     assertEquals(60, decisionLogs.getMinDelaySeconds());
     assertEquals(120, decisionLogs.getMaxDelaySeconds());
   }


### PR DESCRIPTION
## Summary
- Rename the decision logs config accessor from `getDropDedcision` / `setDropDedcision` to `getDropDecision` / `setDropDecision`.
- Update `DecisionLogPlugin` and related tests to use the corrected accessor.
- Keep the YAML/JSON config property name `drop_decision` unchanged.

Fixes #75

## Testing
- `JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8 ./gradlew.bat --no-daemon :opa-services:test --tests "io.github.open_policy_agent.opa.config.ConfigTest" --tests "io.github.open_policy_agent.opa.plugins.DecisionLogPluginTest"`
- `JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8 ./gradlew.bat --no-daemon :opa-services:checkstyleMain :opa-services:checkstyleTest`
