### PR TITLE
refactor: consolidate statement type names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+### Breaking Changes
+
+* Renamed the statement type enum from `Stmt.STMT_TYPE` to `Stmt.StmtType`.
+* Removed duplicate per-statement `StmtType` string constants, such as `ArrayAppendStmt.StmtType`; statement type names now come from `Stmt.StmtType#getTypeName()`.
+* Removed the unused `MakeObjectStmt#getStmtType()` helper.
+
+### Changed
+
+* Updated statement deserialization to use `Stmt.StmtType#getTypeName()` as the single source of statement type names.

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ArrayAppendStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ArrayAppendStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * ArrayAppendStmt represents a dynamic append operation of a value onto an array.
  */
 public class ArrayAppendStmt extends BaseStmt {
-    public static final String StmtType = "ArrayAppendStmt";
 
     private Operand value;
 
@@ -38,8 +37,8 @@ public class ArrayAppendStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.ARRAY_APPEND;
+  public StmtType getType() {
+    return StmtType.ARRAY_APPEND;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/AssignIntStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/AssignIntStmt.java
@@ -6,7 +6,6 @@ import java.util.Objects;
  * AssignIntStmt represents a dynamic append operation of a value onto an array.
  */
 public class AssignIntStmt extends BaseStmt {
-    public static final String StmtType = "AssignIntStmt";
 
     private Long value;
 
@@ -37,8 +36,8 @@ public class AssignIntStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.ASSIGN_INT;
+  public StmtType getType() {
+    return StmtType.ASSIGN_INT;
   }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/AssignVarOnceStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/AssignVarOnceStmt.java
@@ -8,7 +8,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * defined, execution aborts with a conflict error.
  */
 public class AssignVarOnceStmt extends BaseStmt {
-    public static final String StmtType = "AssignVarOnceStmt";
 
     private Operand source;
 
@@ -39,8 +38,8 @@ public class AssignVarOnceStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.ASSIGN_VAR_ONCE;
+  public StmtType getType() {
+    return StmtType.ASSIGN_VAR_ONCE;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/AssignVarStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/AssignVarStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * AssignVarStmt represents an assignment of one local variable to another.
  */
 public class AssignVarStmt extends BaseStmt {
-    public static final String StmtType = "AssignVarStmt";
 
     private Operand source;
 
@@ -38,8 +37,8 @@ public class AssignVarStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.ASSIGN_VAR;
+  public StmtType getType() {
+    return StmtType.ASSIGN_VAR;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/BlockStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/BlockStmt.java
@@ -9,7 +9,6 @@ import io.github.open_policy_agent.opa.ir.policy.Block;
  * short-circuit execution.
  */
 public class BlockStmt extends BaseStmt {
-    public static final String StmtType = "BlockStmt";
 
     private List<Block> blocks;
 
@@ -34,8 +33,8 @@ public class BlockStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.BLOCK;
+  public StmtType getType() {
+    return StmtType.BLOCK;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/BreakStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/BreakStmt.java
@@ -7,7 +7,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * jumped to.
  */
 public class BreakStmt extends BaseStmt {
-    public static final String StmtType = "BreakStmt";
 
     private int index;
 
@@ -31,8 +30,8 @@ public class BreakStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.BREAK;
+  public StmtType getType() {
+    return StmtType.BREAK;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/CallDynamicStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/CallDynamicStmt.java
@@ -9,7 +9,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * result local.
  */
 public class CallDynamicStmt extends BaseStmt {
-    public static final String StmtType = "CallDynamicStmt";
 
     private List<Operand> path;
 
@@ -51,8 +50,8 @@ public class CallDynamicStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.CALL_DYNAMIC;
+  public StmtType getType() {
+    return StmtType.CALL_DYNAMIC;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/CallStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/CallStmt.java
@@ -6,7 +6,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
 
 /** CallStmt represents a named function call. The result should be stored in the result local. */
 public class CallStmt extends BaseStmt {
-  public static final String StmtType = "CallStmt";
 
   private final int maxLocal = Integer.MIN_VALUE;
 
@@ -53,8 +52,8 @@ public class CallStmt extends BaseStmt {
   }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.CALL;
+  public StmtType getType() {
+    return StmtType.CALL;
   }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/DotStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/DotStmt.java
@@ -8,7 +8,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * DotStmt may be a scalar value, in which case the statement will be undefined.
  */
 public class DotStmt extends BaseStmt {
-    public static final String StmtType = "DotStmt";
 
     private Operand source;
 
@@ -26,8 +25,8 @@ public class DotStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.DOT;
+  public StmtType getType() {
+    return StmtType.DOT;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/EqualStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/EqualStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * EqualStmt represents a value-equality check of two local variables.
  */
 public class EqualStmt extends BaseStmt {
-    public static final String StmtType = "EqualStmt";
 
     private Operand a;
 
@@ -39,8 +38,8 @@ public class EqualStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.EQUAL;
+  public StmtType getType() {
+    return StmtType.EQUAL;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/IsArrayStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/IsArrayStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * IsArrayStmt represents a dynamic type check on a local variable.
  */
 public class IsArrayStmt extends BaseStmt {
-    public static final String StmtType = "IsArrayStmt";
 
     private Operand source;
 
@@ -27,8 +26,8 @@ public class IsArrayStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.IS_ARRAY;
+  public StmtType getType() {
+    return StmtType.IS_ARRAY;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/IsDefinedStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/IsDefinedStmt.java
@@ -5,7 +5,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * IsDefinedStmt represents a check of whether a local variable is defined.
  */
 public class IsDefinedStmt extends BaseStmt {
-    public static final String StmtType = "IsDefinedStmt";
 
     private int source;
 
@@ -25,8 +24,8 @@ public class IsDefinedStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.IS_DEFINED;
+  public StmtType getType() {
+    return StmtType.IS_DEFINED;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/IsObjectStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/IsObjectStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * IsObjectStmt represents a dynamic type check on a local variable.
  */
 public class IsObjectStmt extends BaseStmt {
-    public static final String StmtType = "IsObjectStmt";
 
     private Operand source;
 
@@ -27,8 +26,8 @@ public class IsObjectStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.IS_OBJECT;
+  public StmtType getType() {
+    return StmtType.IS_OBJECT;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/IsSetStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/IsSetStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * IsSetStmt represents a dynamic type check on a local variable.
  */
 public class IsSetStmt extends BaseStmt {
-    public static final String StmtType = "IsSetStmt";
 
     private Operand source;
 
@@ -27,8 +26,8 @@ public class IsSetStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.IS_SET;
+  public StmtType getType() {
+    return StmtType.IS_SET;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/IsUndefinedStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/IsUndefinedStmt.java
@@ -5,7 +5,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * IsUndefinedStmt represents a check of whether a local variable is undefined.
  */
 public class IsUndefinedStmt extends BaseStmt {
-    public static final String StmtType = "IsUndefinedStmt";
 
     private int source;
 
@@ -25,8 +24,8 @@ public class IsUndefinedStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.IS_UNDEFINED;
+  public StmtType getType() {
+    return StmtType.IS_UNDEFINED;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/LenStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/LenStmt.java
@@ -8,7 +8,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * local variable.
  */
 public class LenStmt extends BaseStmt {
-    public static final String StmtType = "LenStmt";
 
     private Operand source;
 
@@ -39,8 +38,8 @@ public class LenStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.LEN;
+  public StmtType getType() {
+    return StmtType.LEN;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeArrayStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeArrayStmt.java
@@ -5,7 +5,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * MakeArrayStmt constructs a local variable that refers to an array value.
  */
 public class MakeArrayStmt extends BaseStmt {
-    public static final String StmtType = "MakeArrayStmt";
 
     private int capacity;
 
@@ -36,8 +35,8 @@ public class MakeArrayStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.MAKE_ARRAY;
+  public StmtType getType() {
+    return StmtType.MAKE_ARRAY;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeNullStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeNullStmt.java
@@ -5,7 +5,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * MakeNullStmt constructs a local variable that refers to a null value.
  */
 public class MakeNullStmt extends BaseStmt {
-    public static final String StmtType = "MakeNullStmt";
 
     private int target;
 
@@ -25,8 +24,8 @@ public class MakeNullStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.MAKE_NULL;
+  public StmtType getType() {
+    return StmtType.MAKE_NULL;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeNumberIntStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeNumberIntStmt.java
@@ -5,7 +5,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * MakeNumberIntStmt constructs a local variable that refers to an integer value.
  */
 public class MakeNumberIntStmt extends BaseStmt {
-    public static final String StmtType = "MakeNumberIntStmt";
 
     private long value;
 
@@ -36,8 +35,8 @@ public class MakeNumberIntStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.MAKE_NUMBER_INT;
+  public StmtType getType() {
+    return StmtType.MAKE_NUMBER_INT;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeNumberRefStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeNumberRefStmt.java
@@ -4,7 +4,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * MakeNumberRefStmt constructs a local variable that refers to a number stored as a string.
  */
 public class MakeNumberRefStmt extends BaseStmt {
-    public static final String StmtType = "MakeNumberRefStmt";
 
     private int index;
 
@@ -35,8 +34,8 @@ public class MakeNumberRefStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.MAKE_NUMBER_REF;
+  public StmtType getType() {
+    return StmtType.MAKE_NUMBER_REF;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeObjectStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeObjectStmt.java
@@ -5,7 +5,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * MakeObjectStmt constructs a local variable that refers to an object value.
  */
 public class MakeObjectStmt extends BaseStmt {
-    public static final String StmtType = "MakeObjectStmt";
 
     private int target;
 
@@ -24,13 +23,9 @@ public class MakeObjectStmt extends BaseStmt {
         this.target = target;
     }
 
-    public String getStmtType() {
-        return StmtType;
-    }
-
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.MAKE_OBJECT;
+  public StmtType getType() {
+    return StmtType.MAKE_OBJECT;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeSetStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/MakeSetStmt.java
@@ -5,7 +5,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * MakeSetStmt constructs a local variable that refers to a set value.
  */
 public class MakeSetStmt extends BaseStmt {
-    public static final String StmtType = "MakeSetStmt";
 
     private int target;
 
@@ -25,8 +24,8 @@ public class MakeSetStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.MAKE_SET;
+  public StmtType getType() {
+    return StmtType.MAKE_SET;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/NopStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/NopStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.IREvaluationContext;
  * NopStmt adds a nop instruction. Useful during development and debugging only.
  */
 public class NopStmt extends BaseStmt {
-    public static final String StmtType = "NopStmt";
 
     public NopStmt() {
     }
@@ -20,8 +19,8 @@ public class NopStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.NOP;
+  public StmtType getType() {
+    return StmtType.NOP;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/NotEqualStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/NotEqualStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * NotEqualStmt represents a != check of two local variables.
  */
 public class NotEqualStmt extends BaseStmt {
-    public static final String StmtType = "NotEqualStmt";
 
     private Operand a;
 
@@ -40,8 +39,8 @@ public class NotEqualStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.NOT_EQUAL;
+  public StmtType getType() {
+    return StmtType.NOT_EQUAL;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/NotStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/NotStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.policy.Block;
  * NotStmt represents a negated statement.
  */
 public class NotStmt extends BaseStmt {
-    public static final String StmtType = "NotStmt";
 
     private Block block;
 
@@ -28,8 +27,8 @@ public class NotStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.NOT;
+  public StmtType getType() {
+    return StmtType.NOT;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ObjectInsertOnceStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ObjectInsertOnceStmt.java
@@ -8,7 +8,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * the key already exists and the value differs, execution aborts with a conflict error.
  */
 public class ObjectInsertOnceStmt extends BaseStmt {
-    public static final String StmtType = "ObjectInsertOnceStmt";
 
     private Operand key;
 
@@ -50,8 +49,8 @@ public class ObjectInsertOnceStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.OBJECT_INSERT_ONCE;
+  public StmtType getType() {
+    return StmtType.OBJECT_INSERT_ONCE;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ObjectInsertStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ObjectInsertStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * ObjectInsertStmt represents a dynamic insert operation of a key/value pair into an object.
  */
 public class ObjectInsertStmt extends BaseStmt {
-    public static final String StmtType = "ObjectInsertStmt";
 
     private Operand key;
 
@@ -51,8 +50,8 @@ public class ObjectInsertStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.OBJECT_INSERT;
+  public StmtType getType() {
+    return StmtType.OBJECT_INSERT;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ObjectMergeStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ObjectMergeStmt.java
@@ -7,7 +7,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * merged recursively.
  */
 public class ObjectMergeStmt extends BaseStmt {
-    public static final String StmtType = "ObjectMergeStmt";
 
     private int a;
 
@@ -25,8 +24,8 @@ public class ObjectMergeStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.OBJECT_MERGE;
+  public StmtType getType() {
+    return StmtType.OBJECT_MERGE;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ResetLocalStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ResetLocalStmt.java
@@ -5,7 +5,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * ResetLocalStmt resets a local variable to 0.
  */
 public class ResetLocalStmt extends BaseStmt {
-    public static final String StmtType = "ResetLocalStmt";
 
     private int target;
 
@@ -25,8 +24,8 @@ public class ResetLocalStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.RESET_LOCAL;
+  public StmtType getType() {
+    return StmtType.RESET_LOCAL;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ResultSetAddStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ResultSetAddStmt.java
@@ -5,7 +5,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * ResultSetAddStmt adds a value into the result set returned by the query plan.
  */
 public class ResultSetAddStmt extends BaseStmt {
-    public static final String StmtType = "ResultSetAddStmt";
 
     private int value;
 
@@ -25,8 +24,8 @@ public class ResultSetAddStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.RESULT_SET_ADD;
+  public StmtType getType() {
+    return StmtType.RESULT_SET_ADD;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ReturnLocalStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ReturnLocalStmt.java
@@ -5,7 +5,6 @@ package io.github.open_policy_agent.opa.ir.stmts;
  * ReturnLocalStmt represents a return statement that yields a local value.
  */
 public class ReturnLocalStmt extends BaseStmt {
-    public static final String StmtType = "ReturnLocalStmt";
 
     private int source;
 
@@ -25,8 +24,8 @@ public class ReturnLocalStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.RETURN_LOCAL;
+  public StmtType getType() {
+    return StmtType.RETURN_LOCAL;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ScanStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/ScanStmt.java
@@ -9,7 +9,6 @@ import io.github.open_policy_agent.opa.ir.policy.Block;
  * case the block will never execute.
  */
 public class ScanStmt extends BaseStmt {
-    public static final String StmtType = "ScanStmt";
 
     private int source;
 
@@ -30,8 +29,8 @@ public class ScanStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.SCAN;
+  public StmtType getType() {
+    return StmtType.SCAN;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/SetAddStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/SetAddStmt.java
@@ -7,7 +7,6 @@ import io.github.open_policy_agent.opa.ir.Operand;
  * SetAddStmt represents a dynamic add operation of an element into a set.
  */
 public class SetAddStmt extends BaseStmt {
-    public static final String StmtType = "SetAddStmt";
 
     private Operand value;
 
@@ -38,8 +37,8 @@ public class SetAddStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.SET_ADD;
+  public StmtType getType() {
+    return StmtType.SET_ADD;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/Stmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/Stmt.java
@@ -5,9 +5,9 @@ package io.github.open_policy_agent.opa.ir.stmts;
  */
 public interface Stmt extends LocationStmt {
 
-  STMT_TYPE getType();
+  StmtType getType();
 
-  enum STMT_TYPE {
+  enum StmtType {
     ARRAY_APPEND("ArrayAppendStmt"),
     ASSIGN_INT("AssignIntStmt"),
     ASSIGN_VAR_ONCE("AssignVarOnceStmt"),
@@ -45,12 +45,12 @@ public interface Stmt extends LocationStmt {
 
     private final String typeName;
 
-    STMT_TYPE(String typeName) {
+    StmtType(String typeName) {
       this.typeName = typeName;
     }
 
-    public static STMT_TYPE fromTypeName(String typeName) {
-      for (STMT_TYPE type : STMT_TYPE.values()) {
+    public static StmtType fromTypeName(String typeName) {
+      for (StmtType type : StmtType.values()) {
         if (type.typeName.equals(typeName)) {
           return type;
         }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/WithStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/WithStmt.java
@@ -12,7 +12,6 @@ import io.github.open_policy_agent.opa.ir.policy.Block;
  * created. When the WithStmt finishes, the Local is reset to its original value.
  */
 public class WithStmt extends BaseStmt {
-    public static final String StmtType = "WithStmt";
 
     private int local;
 
@@ -65,8 +64,8 @@ public class WithStmt extends BaseStmt {
     }
 
   @Override
-  public STMT_TYPE getType() {
-    return STMT_TYPE.WITH;
+  public StmtType getType() {
+    return StmtType.WITH;
     }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/profiling/SimpleStatementProfiler.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/profiling/SimpleStatementProfiler.java
@@ -4,7 +4,7 @@ import java.time.Duration;
 import java.util.*;
 import io.github.open_policy_agent.opa.ir.stmts.CallStmt;
 import io.github.open_policy_agent.opa.ir.stmts.Stmt;
-import io.github.open_policy_agent.opa.ir.stmts.Stmt.STMT_TYPE;
+import io.github.open_policy_agent.opa.ir.stmts.Stmt.StmtType;
 
 /**
  * Simple implementation of StatementProfiler that tracks statement execution time and frequency.
@@ -67,7 +67,7 @@ public class SimpleStatementProfiler implements StatementProfiler {
    * @return a human-readable name for the statement
    */
   private String getStatementName(Stmt stmt) {
-    if (stmt.getType() == STMT_TYPE.CALL) {
+    if (stmt.getType() == StmtType.CALL) {
       return ((CallStmt) stmt).getFunc();
     } else {
       return stmt.getType().getTypeName();

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/ComplianceTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/ComplianceTest.java
@@ -58,10 +58,10 @@ public class ComplianceTest {
       Pattern.compile("^[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]*\\.[A-Za-z0-9_-]*$");
   private static final PolicyReader POLICY_READER =
       ServiceLoader.load(PolicyReader.class).findFirst().orElseThrow();
-  private static final String complianceDir;
-  private static final Set<String> missingFunctions = ConcurrentHashMap.newKeySet();
+  private static String complianceDir;
+  private static  Set<String> missingFunctions = ConcurrentHashMap.newKeySet();
 
-  private static final boolean ignoreFunctionNotFoundTests = true;
+  private static  boolean ignoreFunctionNotFoundTests = true;
 
   /**
    * Alternate acceptable error message substrings for tests where the Java IR evaluator produces a

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/EvaluatorTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/EvaluatorTest.java
@@ -30,9 +30,9 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 
 class EvaluatorTest {
-  private static final PolicyReader policyReader =
+  private static PolicyReader policyReader =
       ServiceLoader.load(PolicyReader.class).findFirst().orElseThrow();
-  private static final ObjectMapper objectMapper = new ObjectMapper().registerModule(new io.github.open_policy_agent.opa.jackson.RegoValueModule());
+  private static ObjectMapper objectMapper = new ObjectMapper().registerModule(new io.github.open_policy_agent.opa.jackson.RegoValueModule());
 
   @Test
   void evaluate_BreakStmt_IndexZero() throws IOException {

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/PolicyTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/PolicyTest.java
@@ -19,7 +19,7 @@ import io.github.open_policy_agent.opa.ir.vals.LocalVal;
 import io.github.open_policy_agent.opa.ir.vals.StringIndexVal;
 
 class PolicyTest {
-  private static final PolicyReader policyReader =
+  private static PolicyReader policyReader =
       ServiceLoader.load(PolicyReader.class).findFirst().orElseThrow();
 
   @Test

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/rego/EngineTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/rego/EngineTest.java
@@ -28,9 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class EngineTest {
-  private static final PolicyReader policyReader =
+  private static PolicyReader policyReader =
       ServiceLoader.load(PolicyReader.class).findFirst().orElseThrow();
-  private static final ObjectMapper objectMapper = new ObjectMapper().registerModule(new io.github.open_policy_agent.opa.jackson.RegoValueModule());
+  private static ObjectMapper objectMapper = new ObjectMapper().registerModule(new io.github.open_policy_agent.opa.jackson.RegoValueModule());
 
   @Test
   void engine_builder_requiresStore() {

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/tracing/CoverageProfilerIntegrationTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/tracing/CoverageProfilerIntegrationTest.java
@@ -24,7 +24,7 @@ import io.github.open_policy_agent.opa.rego.EvaluationContext;
  */
 class CoverageProfilerIntegrationTest {
 
-  private static final PolicyReader policyReader =
+  private static PolicyReader policyReader =
       ServiceLoader.load(PolicyReader.class).findFirst().orElseThrow();
 
   private Policy loadPolicy(String resourcePath) throws IOException {

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/StmtDeserializer.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/StmtDeserializer.java
@@ -42,6 +42,7 @@ import io.github.open_policy_agent.opa.ir.stmts.ReturnLocalStmt;
 import io.github.open_policy_agent.opa.ir.stmts.ScanStmt;
 import io.github.open_policy_agent.opa.ir.stmts.SetAddStmt;
 import io.github.open_policy_agent.opa.ir.stmts.Stmt;
+import io.github.open_policy_agent.opa.ir.stmts.Stmt.StmtType;
 import io.github.open_policy_agent.opa.ir.stmts.WithStmt;
 
 import java.io.IOException;
@@ -51,44 +52,44 @@ import java.util.concurrent.ConcurrentHashMap;
 
 class StmtDeserializer extends JsonDeserializer<Stmt> {
   // Maps JSON type strings to statement classes.
-  // String values match the OPA IR spec and the STMT_TYPE enum's typeName values.
+  // String values match the OPA IR spec and the StmtType enum's typeName values.
   private static final Map<String, Class<? extends Stmt>> STMT_REGISTRY =
       new HashMap<>() {
         {
-          put(ArrayAppendStmt.StmtType,       ArrayAppendStmt.class);
-          put(AssignVarOnceStmt.StmtType,     AssignVarOnceStmt.class);
-          put(AssignIntStmt.StmtType,         AssignIntStmt.class);
-          put(AssignVarStmt.StmtType,         AssignVarStmt.class);
-          put(BlockStmt.StmtType,             BlockStmt.class);
-          put(BreakStmt.StmtType,             BreakStmt.class);
-          put(CallDynamicStmt.StmtType,       CallDynamicStmt.class);
-          put(CallStmt.StmtType,              CallStmt.class);
-          put(DotStmt.StmtType,               DotStmt.class);
-          put(EqualStmt.StmtType,             EqualStmt.class);
-          put(IsArrayStmt.StmtType,           IsArrayStmt.class);
-          put(IsDefinedStmt.StmtType,         IsDefinedStmt.class);
-          put(IsObjectStmt.StmtType,          IsObjectStmt.class);
-          put(IsUndefinedStmt.StmtType,       IsUndefinedStmt.class);
-          put(IsSetStmt.StmtType,             IsSetStmt.class);
-          put(LenStmt.StmtType,               LenStmt.class);
-          put(MakeArrayStmt.StmtType,         MakeArrayStmt.class);
-          put(MakeNullStmt.StmtType,          MakeNullStmt.class);
-          put(MakeNumberIntStmt.StmtType,     MakeNumberIntStmt.class);
-          put(MakeNumberRefStmt.StmtType,     MakeNumberRefStmt.class);
-          put(MakeObjectStmt.StmtType,        MakeObjectStmt.class);
-          put(MakeSetStmt.StmtType,           MakeSetStmt.class);
-          put(NotEqualStmt.StmtType,          NotEqualStmt.class);
-          put(NotStmt.StmtType,               NotStmt.class);
-          put(ObjectInsertOnceStmt.StmtType,  ObjectInsertOnceStmt.class);
-          put(ObjectInsertStmt.StmtType,      ObjectInsertStmt.class);
-          put(ObjectMergeStmt.StmtType,       ObjectMergeStmt.class);
-          put(ResetLocalStmt.StmtType,        ResetLocalStmt.class);
-          put(ResultSetAddStmt.StmtType,      ResultSetAddStmt.class);
-          put(ReturnLocalStmt.StmtType,       ReturnLocalStmt.class);
-          put(ScanStmt.StmtType,              ScanStmt.class);
-          put(SetAddStmt.StmtType,            SetAddStmt.class);
-          put(WithStmt.StmtType,              WithStmt.class);
-          put(NopStmt.StmtType,               NopStmt.class);
+          put(StmtType.ARRAY_APPEND.getTypeName(),       ArrayAppendStmt.class);
+          put(StmtType.ASSIGN_VAR_ONCE.getTypeName(),     AssignVarOnceStmt.class);
+          put(StmtType.ASSIGN_INT.getTypeName(),         AssignIntStmt.class);
+          put(StmtType.ASSIGN_VAR.getTypeName(),         AssignVarStmt.class);
+          put(StmtType.BLOCK.getTypeName(),             BlockStmt.class);
+          put(StmtType.BREAK.getTypeName(),             BreakStmt.class);
+          put(StmtType.CALL_DYNAMIC.getTypeName(),       CallDynamicStmt.class);
+          put(StmtType.CALL.getTypeName(),              CallStmt.class);
+          put(StmtType.DOT.getTypeName(),               DotStmt.class);
+          put(StmtType.EQUAL.getTypeName(),             EqualStmt.class);
+          put(StmtType.IS_ARRAY.getTypeName(),           IsArrayStmt.class);
+          put(StmtType.IS_DEFINED.getTypeName(),         IsDefinedStmt.class);
+          put(StmtType.IS_OBJECT.getTypeName(),          IsObjectStmt.class);
+          put(StmtType.IS_UNDEFINED.getTypeName(),       IsUndefinedStmt.class);
+          put(StmtType.IS_SET.getTypeName(),             IsSetStmt.class);
+          put(StmtType.LEN.getTypeName(),               LenStmt.class);
+          put(StmtType.MAKE_ARRAY.getTypeName(),         MakeArrayStmt.class);
+          put(StmtType.MAKE_NULL.getTypeName(),          MakeNullStmt.class);
+          put(StmtType.MAKE_NUMBER_INT.getTypeName(),     MakeNumberIntStmt.class);
+          put(StmtType.MAKE_NUMBER_REF.getTypeName(),     MakeNumberRefStmt.class);
+          put(StmtType.MAKE_OBJECT.getTypeName(),        MakeObjectStmt.class);
+          put(StmtType.MAKE_SET.getTypeName(),           MakeSetStmt.class);
+          put(StmtType.NOT_EQUAL.getTypeName(),          NotEqualStmt.class);
+          put(StmtType.NOT.getTypeName(),               NotStmt.class);
+          put(StmtType.OBJECT_INSERT_ONCE.getTypeName(),  ObjectInsertOnceStmt.class);
+          put(StmtType.OBJECT_INSERT.getTypeName(),      ObjectInsertStmt.class);
+          put(StmtType.OBJECT_MERGE.getTypeName(),       ObjectMergeStmt.class);
+          put(StmtType.RESET_LOCAL.getTypeName(),        ResetLocalStmt.class);
+          put(StmtType.RESULT_SET_ADD.getTypeName(),      ResultSetAddStmt.class);
+          put(StmtType.RETURN_LOCAL.getTypeName(),       ReturnLocalStmt.class);
+          put(StmtType.SCAN.getTypeName(),              ScanStmt.class);
+          put(StmtType.SET_ADD.getTypeName(),            SetAddStmt.class);
+          put(StmtType.WITH.getTypeName(),              WithStmt.class);
+          put(StmtType.NOP.getTypeName(),               NopStmt.class);
         }
       };
 


### PR DESCRIPTION
## Summary

Closes #91.

* Renamed the statement type enum from `Stmt.STMT_TYPE` to `Stmt.StmtType`.
* Removed duplicate per-statement `StmtType` string constants from statement classes.
* Updated `StmtDeserializer` to use `Stmt.StmtType#getTypeName()` as the single source for statement type strings.
* Removed the unused `MakeObjectStmt#getStmtType()` helper.
* Updated lowercase `static final` test helper fields so they are not treated as constants.
* Added a changelog note for the breaking enum rename.

## Validation

* `./gradlew.bat :opa-evaluator:compileJava :opa-jackson:compileJava :opa-evaluator:compileTestJava :opa-jackson:compileTestJava`
* `./gradlew.bat :opa-evaluator:checkstyleMain :opa-evaluator:checkstyleTest :opa-jackson:checkstyleMain 2>&1 | Select-String "ConstantName"`

Note: remaining `ConstantName` warnings are unrelated existing items such as `AllBuiltIns` and `TypeMarker`, outside this statement-type cleanup scope.
