### PR TITLE
fix: mop up long-tail checkstyle violations

### DIFF
--- a/opa-builtins/opa-builtins-net/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/CidrBuiltins.java
+++ b/opa-builtins/opa-builtins-net/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/CidrBuiltins.java
@@ -16,7 +16,6 @@ import io.github.open_policy_agent.opa.ast.builtin.BuiltinProvider;
 import io.github.open_policy_agent.opa.ast.builtin.OpaBuiltin;
 import io.github.open_policy_agent.opa.ast.builtin.OpaDynamic;
 import io.github.open_policy_agent.opa.ast.builtin.OpaType;
-import io.github.open_policy_agent.opa.ast.builtin.impls.utils.ArgHelper;
 import io.github.open_policy_agent.opa.ast.types.*;
 import io.github.open_policy_agent.opa.rego.EvaluationContext;
 

--- a/opa-builtins/opa-builtins-time/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/TimeBuiltins.java
+++ b/opa-builtins/opa-builtins-time/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/TimeBuiltins.java
@@ -49,7 +49,10 @@ public class TimeBuiltins implements BuiltinProvider {
             type = "any",
             name = "x",
             description =
-                "a number representing the nanoseconds since the epoch (UTC); or a two-element array of the nanoseconds, and a timezone string; or a three-element array of ns, timezone string and a layout string or golang defined formatting constant (see golang supported time formats)")
+                "a number representing the nanoseconds since the epoch (UTC); or a "
+                    + "two-element array of the nanoseconds, and a timezone string; or a "
+                    + "three-element array of ns, timezone string and a layout string or "
+                    + "golang defined formatting constant (see golang supported time formats)")
       },
       result =
           @OpaType(
@@ -264,7 +267,11 @@ public class TimeBuiltins implements BuiltinProvider {
   @OpaBuiltin(
       name = "time.add_date",
       description =
-          "Returns the nanoseconds since epoch after adding years, months and days to nanoseconds. Month & day values outside their usual ranges after the operation and will be normalized - for example, October 32 would become November 1. `undefined` if the result would be outside the valid time range that can fit within an `int64`.",
+          "Returns the nanoseconds since epoch after adding years, months and days to "
+              + "nanoseconds. Month & day values outside their usual ranges after the operation "
+              + "and will be normalized - for example, October 32 would become November 1. "
+              + "`undefined` if the result would be outside the valid time range that can fit "
+              + "within an `int64`.",
       args = {
         @OpaType(type = "number", name = "ns", description = "nanoseconds since the epoch"),
         @OpaType(type = "number", name = "years", description = "number of years to add"),

--- a/opa-builtins/opa-builtins-token/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/TokenBuiltins.java
+++ b/opa-builtins/opa-builtins-token/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/TokenBuiltins.java
@@ -694,7 +694,9 @@ public class TokenBuiltins implements BuiltinProvider {
   @OpaBuiltin(
       name = "io.jwt.decode_verify",
       description =
-          "Verifies a JWT signature under parameterized constraints and decodes the claims if it is valid.\nSupports the following algorithms: HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512, and EdDSA.",
+          "Verifies a JWT signature under parameterized constraints and decodes the claims if "
+              + "it is valid.\nSupports the following algorithms: HS256, HS384, HS512, RS256, "
+              + "RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512, and EdDSA.",
       args = {
         @OpaType(
             type = "string",
@@ -711,7 +713,10 @@ public class TokenBuiltins implements BuiltinProvider {
               type = "array",
               name = "output",
               description =
-                  "`[valid, header, payload]`:  if the input token is verified and meets the requirements of `constraints` then `valid` is `true`; `header` and `payload` are objects containing the JOSE header and the JWT claim set; otherwise, `valid` is `false`, `header` and `payload` are `{}`"),
+                  "`[valid, header, payload]`:  if the input token is verified and meets the "
+                      + "requirements of `constraints` then `valid` is `true`; `header` and "
+                      + "`payload` are objects containing the JOSE header and the JWT claim set; "
+                      + "otherwise, `valid` is `false`, `header` and `payload` are `{}`"),
       nondeterministic = true)
   public RegoArray decodeVerify(EvaluationContext ctx, RegoValue[] args) {
     // Check cache first

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/ObjectBuiltins.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/ObjectBuiltins.java
@@ -32,7 +32,11 @@ public class ObjectBuiltins {
   @OpaBuiltin(
       name = "object.union_n",
       description =
-          "Returns a new object containing all key/value pairs from the supplied objects. If the supplied `objects` is an `array`, then `object.union_n` will search through a nested object or array using each key in turn. For example: `object.union_n([{\"a\": 1}, {\"b\": 2}, {\"c\": 3}])` results in `{\"a\": 1, \"b\": 2, \"c\": 3}`.",
+          "Returns a new object containing all key/value pairs from the supplied objects. "
+              + "If the supplied `objects` is an `array`, then `object.union_n` will search "
+              + "through a nested object or array using each key in turn. For example: "
+              + "`object.union_n([{\"a\": 1}, {\"b\": 2}, {\"c\": 3}])` results in "
+              + "`{\"a\": 1, \"b\": 2, \"c\": 3}`.",
       args = {
         @OpaType(
             type = "array",
@@ -91,7 +95,20 @@ public class ObjectBuiltins {
   @OpaBuiltin(
       name = "object.subset",
       description =
-          "Determines if an object `sub` is a subset of another object `super`.Object `sub` is a subset of object `super` if and only if every key in `sub` is also in `super`, **and** for all keys which `sub` and `super` share, they have the same value. This function works with objects, sets, arrays and a set of array and set.If both arguments are objects, then the operation is recursive, e.g. `{\"c\": {\"x\": {10, 15, 20}}` is a subset of `{\"a\": \"b\", \"c\": {\"x\": {10, 15, 20, 25}, \"y\": \"z\"}}`. If both arguments are sets, then this function checks if every element of `sub` is a member of `super`, but does not attempt to recurse. If both arguments are arrays, then this function checks if `sub` appears contiguously in order within `super`, and also does not attempt to recurse. If `super` is array and `sub` is set, then this function checks if `super` contains every element of `sub` with no consideration of ordering, and also does not attempt to recurse.",
+          "Determines if an object `sub` is a subset of another object `super`."
+              + "Object `sub` is a subset of object `super` if and only if every key in `sub` "
+              + "is also in `super`, **and** for all keys which `sub` and `super` share, they "
+              + "have the same value. This function works with objects, sets, arrays and a set "
+              + "of array and set.If both arguments are objects, then the operation is "
+              + "recursive, e.g. `{\"c\": {\"x\": {10, 15, 20}}` is a subset of "
+              + "`{\"a\": \"b\", \"c\": {\"x\": {10, 15, 20, 25}, \"y\": \"z\"}}`. "
+              + "If both arguments are sets, then this function checks if every element of "
+              + "`sub` is a member of `super`, but does not attempt to recurse. If both "
+              + "arguments are arrays, then this function checks if `sub` appears contiguously "
+              + "in order within `super`, and also does not attempt to recurse. If `super` is "
+              + "array and `sub` is set, then this function checks if `super` contains every "
+              + "element of `sub` with no consideration of ordering, and also does not attempt "
+              + "to recurse.",
       args = {
         @OpaType(
             type = "object|set|array",
@@ -200,7 +217,11 @@ public class ObjectBuiltins {
   @OpaBuiltin(
       name = "object.remove",
       description =
-          "Returns a new object containing all key/value pairs except for those for which the key is present in the supplied set. If the supplied `keys` is an `array`, then `object.remove` will search through a nested object or array using each key in turn. For example: `object.remove({\"a\": [{ \"b\": true }]}, [\"a\", 0, \"b\"])` results in `{\"a\": []}`.",
+          "Returns a new object containing all key/value pairs except for those for which the "
+              + "key is present in the supplied set. If the supplied `keys` is an `array`, then "
+              + "`object.remove` will search through a nested object or array using each key in "
+              + "turn. For example: `object.remove({\"a\": [{ \"b\": true }]}, "
+              + "[\"a\", 0, \"b\"])` results in `{\"a\": []}`.",
       args = {
         @OpaType(
             type = "object",
@@ -227,7 +248,9 @@ public class ObjectBuiltins {
     RegoObject object = (RegoObject) args[0];
 
     if (!(args[1] instanceof RegoObject) && !(args[1] instanceof RegoSet) && !(args[1] instanceof RegoArray)) {
-      throw new TypeError("object.remove: operand 2 must be one of {object, set, array} but got " + args[1].getTypeName());
+      throw new TypeError(
+          "object.remove: operand 2 must be one of {object, set, array} but got "
+              + args[1].getTypeName());
     }
     RegoValue keys = args[1];
 
@@ -252,7 +275,11 @@ public class ObjectBuiltins {
   @OpaBuiltin(
       name = "object.filter",
       description =
-          "Returns a new object containing only the key/value pairs for which the key is present in the supplied set. If the supplied `keys` is an `array`, then `object.filter` will search through a nested object or array using each key in turn. For example: `object.filter({\"a\": [{ \"b\": true }]}, [\"a\", 0, \"b\"])` results in `{\"a\": [{ \"b\": true }]}`.",
+          "Returns a new object containing only the key/value pairs for which the key is present "
+              + "in the supplied set. If the supplied `keys` is an `array`, then "
+              + "`object.filter` will search through a nested object or array using each key in "
+              + "turn. For example: `object.filter({\"a\": [{ \"b\": true }]}, "
+              + "[\"a\", 0, \"b\"])` results in `{\"a\": [{ \"b\": true }]}`.",
       args = {
         @OpaType(
             type = "object",
@@ -304,7 +331,11 @@ public class ObjectBuiltins {
   @OpaBuiltin(
       name = "object.get",
       description =
-          "Returns value of an object's key if present, otherwise a default. If the supplied `key` is an `array`, then `object.get` will search through a nested object or array using each key in turn. For example: `object.get({\"a\": [{ \"b\": true }]}, [\"a\", 0, \"b\"], false)` results in `true`.",
+          "Returns value of an object's key if present, otherwise a default. If the supplied "
+              + "`key` is an `array`, then `object.get` will search through a nested object or "
+              + "array using each key in turn. For example: "
+              + "`object.get({\"a\": [{ \"b\": true }]}, [\"a\", 0, \"b\"], false)` results "
+              + "in `true`.",
       args = {
         @OpaType(
             type = "object",

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/SetBuiltins.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/SetBuiltins.java
@@ -10,7 +10,6 @@ import io.github.open_policy_agent.opa.ast.builtin.OpaBuiltin;
 import io.github.open_policy_agent.opa.ast.builtin.OpaDynamic;
 import io.github.open_policy_agent.opa.ast.builtin.OpaType;
 import io.github.open_policy_agent.opa.ast.types.RegoSet;
-import io.github.open_policy_agent.opa.ast.types.RegoString;
 import io.github.open_policy_agent.opa.ast.types.RegoValue;
 import io.github.open_policy_agent.opa.rego.EvaluationContext;
 

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/utils/GoTimeLayoutConverter.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/utils/GoTimeLayoutConverter.java
@@ -48,6 +48,8 @@ public class GoTimeLayoutConverter {
         return new String[] {"yyyy-MM-dd'T'HH:mm:ssXXX", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX"};
       case "RFC3339Nano":
         return new String[] {"yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX", "yyyy-MM-dd'T'HH:mm:ssXXX"};
+      default:
+        break;
     }
 
     // Go's reference time: Mon Jan 2 15:04:05 MST 2006

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/utils/SprintfUtil.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/utils/SprintfUtil.java
@@ -998,9 +998,6 @@ public class SprintfUtil {
     // Go's default %g precision is 6 significant digits, but removes trailing zeros
     if (precision >= 0) {
             formatBuilder.append(".").append(precision);
-    } else if (verb == 'g' || verb == 'G') {
-      // For %g without explicit precision, use -1 which means "shortest"
-      // But Java's %g defaults to 6, so we'll post-process to remove trailing zeros
     }
 
         // Add the verb

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/types/RegoNull.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/types/RegoNull.java
@@ -18,8 +18,14 @@ public class RegoNull implements RegoValue {
 
     public String getTypeName() { return "null";}
 
+  @Override
   public boolean equals(Object o) {
     return o instanceof RegoNull;
+  }
+
+  @Override
+  public int hashCode() {
+    return RegoNull.class.hashCode();
   }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/types/RegoSet.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/types/RegoSet.java
@@ -137,6 +137,11 @@ public class RegoSet implements RegoValue, RegoCollection {
     }
 
     @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
     public String toString() {
         return value.toString();
     }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/types/RegoUndefined.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/types/RegoUndefined.java
@@ -20,8 +20,14 @@ public class RegoUndefined implements RegoValue {
     return "undefined";
   }
 
+  @Override
   public boolean equals(Object o) {
     return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return System.identityHashCode(this);
   }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/Evaluator.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/Evaluator.java
@@ -397,9 +397,7 @@ public class Evaluator implements io.github.open_policy_agent.opa.rego.Evaluator
               RegoValue a = resolveOperand(es.getA(), ctx, frame);
               RegoValue b = resolveOperand(es.getB(), ctx, frame);
               // null doesn't equal null except in Rego :)
-              if (a == null && b == null) {
-                // continue with next statement
-              } else if (a == null || !a.equals(b)) {
+              if ((a != null || b != null) && (a == null || !a.equals(b))) {
                 return false;
               }
               break;

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/types/RegoValueEqualsHashCodeTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/types/RegoValueEqualsHashCodeTest.java
@@ -1,0 +1,54 @@
+package io.github.open_policy_agent.opa.ast.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Constructor;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RegoValueEqualsHashCodeTest {
+
+  @Test
+  void equalRegoSetsHaveSameHashCode() {
+    RegoSet first = setOf(RegoInt32.of(1), new RegoString("two"));
+    RegoSet second = setOf(RegoInt32.of(1), new RegoString("two"));
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
+  void hashSetFindsEquivalentRegoSet() {
+    Set<RegoSet> values = new HashSet<>();
+    values.add(setOf(RegoInt32.of(1), new RegoString("two")));
+
+    assertTrue(values.contains(setOf(RegoInt32.of(1), new RegoString("two"))));
+  }
+
+  @Test
+  void regoNullEqualInstancesHaveSameHashCode() throws ReflectiveOperationException {
+    Constructor<RegoNull> constructor = RegoNull.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    RegoNull other = constructor.newInstance();
+
+    assertEquals(RegoNull.INSTANCE, other);
+    assertEquals(RegoNull.INSTANCE.hashCode(), other.hashCode());
+  }
+
+  @Test
+  void regoUndefinedUsesIdentityHashCode() {
+    assertFalse(RegoUndefined.INSTANCE.equals(RegoUndefined.INSTANCE));
+    assertEquals(System.identityHashCode(RegoUndefined.INSTANCE), RegoUndefined.INSTANCE.hashCode());
+  }
+
+  private static RegoSet setOf(RegoValue... values) {
+    RegoSet set = new RegoSet(false);
+    for (RegoValue value : values) {
+      set.addValue(value);
+    }
+    return set;
+  }
+}

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/PolicyTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/PolicyTest.java
@@ -2,7 +2,6 @@ package io.github.open_policy_agent.opa.ir;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.open_policy_agent.opa.ir.PolicyReader;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/mapper/RegoMapperTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/mapper/RegoMapperTest.java
@@ -34,7 +34,7 @@ class RegoMapperTest {
     private int age;
     private boolean active;
 
-    public SimplePojo() {}
+    SimplePojo() {}
 
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
@@ -48,7 +48,7 @@ class RegoMapperTest {
     private String street;
     private String city;
 
-    public Address() {}
+    Address() {}
 
     public String getStreet() { return street; }
     public void setStreet(String street) { this.street = street; }
@@ -61,7 +61,7 @@ class RegoMapperTest {
     private Address address;
     private List<String> tags;
 
-    public NestedPojo() {}
+    NestedPojo() {}
 
     public String getId() { return id; }
     public void setId(String id) { this.id = id; }
@@ -81,7 +81,7 @@ class RegoMapperTest {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String optional;
 
-    public AnnotatedPojo() {}
+    AnnotatedPojo() {}
 
     public String getUserName() { return userName; }
     public void setUserName(String userName) { this.userName = userName; }
@@ -96,7 +96,7 @@ class RegoMapperTest {
     private Set<Integer> scores;
     private Map<String, String> metadata;
 
-    public CollectionPojo() {}
+    CollectionPojo() {}
 
     public List<Address> getAddresses() { return addresses; }
     public void setAddresses(List<Address> addresses) { this.addresses = addresses; }
@@ -113,7 +113,7 @@ class RegoMapperTest {
     private BigInteger huge;
     private BigDecimal precise;
 
-    public NumberPojo() {}
+    NumberPojo() {}
 
     public long getBigNumber() { return bigNumber; }
     public void setBigNumber(long bigNumber) { this.bigNumber = bigNumber; }
@@ -142,7 +142,7 @@ class RegoMapperTest {
     private Color color;
     private Status status;
 
-    public EnumPojo() {}
+    EnumPojo() {}
 
     public Color getColor() { return color; }
     public void setColor(Color color) { this.color = color; }
@@ -153,7 +153,7 @@ class RegoMapperTest {
   public static class ParentPojo {
     private String parentField;
 
-    public ParentPojo() {}
+    ParentPojo() {}
 
     public String getParentField() { return parentField; }
     public void setParentField(String parentField) { this.parentField = parentField; }
@@ -162,7 +162,7 @@ class RegoMapperTest {
   public static class ChildPojo extends ParentPojo {
     private String childField;
 
-    public ChildPojo() {}
+    ChildPojo() {}
 
     public String getChildField() { return childField; }
     public void setChildField(String childField) { this.childField = childField; }
@@ -1070,7 +1070,7 @@ class RegoMapperTest {
   // Helper class for error tests
   public static class NoDefaultCtorPojo {
     private final String value;
-    public NoDefaultCtorPojo(String value) { this.value = value; }
+    NoDefaultCtorPojo(String value) { this.value = value; }
     public String getValue() { return value; }
   }
 
@@ -1081,7 +1081,7 @@ class RegoMapperTest {
     private final int count;
 
     @JsonCreator
-    public ImmutablePojo(@JsonProperty("name") String name, @JsonProperty("count") int count) {
+    ImmutablePojo(@JsonProperty("name") String name, @JsonProperty("count") int count) {
       this.name = name;
       this.count = count;
     }
@@ -1100,7 +1100,7 @@ class RegoMapperTest {
     private String label;
 
     @JsonCreator
-    public HybridPojo(@JsonProperty("id") String id) {
+    HybridPojo(@JsonProperty("id") String id) {
       this.id = id;
     }
 
@@ -1122,7 +1122,7 @@ class RegoMapperTest {
     private final List<String> roles;
 
     @JsonCreator
-    public CreatorWithCollections(
+    CreatorWithCollections(
         @JsonProperty("name") String name, @JsonProperty("roles") List<String> roles) {
       this.name = name;
       this.roles = roles;
@@ -1142,7 +1142,7 @@ class RegoMapperTest {
     private final Address address;
 
     @JsonCreator
-    public CreatorWithNestedPojo(
+    CreatorWithNestedPojo(
         @JsonProperty("id") String id, @JsonProperty("address") Address address) {
       this.id = id;
       this.address = address;
@@ -1224,7 +1224,7 @@ class RegoMapperTest {
     private final int age;
 
     @JsonCreator
-    public AnnotatedFieldPojo(
+    AnnotatedFieldPojo(
         @JsonProperty("user_name") String userName, @JsonProperty("age") int age) {
       this.userName = userName;
       this.age = age;
@@ -1241,7 +1241,7 @@ class RegoMapperTest {
     private final List<String> items;
 
     @JsonCreator
-    public CreatorNoGetters(
+    CreatorNoGetters(
         @JsonProperty("id") String id, @JsonProperty("items") List<String> items) {
       this.id = id;
       this.items = items;
@@ -1255,7 +1255,7 @@ class RegoMapperTest {
 
     private String getterOnly;
 
-    public MixedAccessPojo() {}
+    MixedAccessPojo() {}
 
     public String getGetterOnly() {
       return getterOnly;
@@ -1302,7 +1302,7 @@ class RegoMapperTest {
     private boolean ckIdentityValid;
     private String httpHeader;
 
-    public ConsecutiveUppercasePojo() {}
+    ConsecutiveUppercasePojo() {}
 
     public String getURL() {
       return url;
@@ -1337,7 +1337,7 @@ class RegoMapperTest {
     private final boolean ckIdentityValid;
     private final String name;
 
-    public AutoDetectPojo(boolean isTrusted, boolean ckIdentityValid, String name) {
+    AutoDetectPojo(boolean isTrusted, boolean ckIdentityValid, String name) {
       this.isTrusted = isTrusted;
       this.ckIdentityValid = ckIdentityValid;
       this.name = name;

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/MetricsIntegrationTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/MetricsIntegrationTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/rego/EngineEvaluateTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/rego/EngineEvaluateTest.java
@@ -304,7 +304,7 @@ class EngineEvaluateTest {
   public static class AuthzInput {
     private User user;
 
-    public AuthzInput() {}
+    AuthzInput() {}
 
     public User getUser() {
       return user;
@@ -318,9 +318,9 @@ class EngineEvaluateTest {
       private String id;
       private List<String> groups;
 
-      public User() {}
+      User() {}
 
-      public User(String id, List<String> groups) {
+      User(String id, List<String> groups) {
         this.id = id;
         this.groups = groups;
       }
@@ -428,7 +428,7 @@ class EngineEvaluateTest {
 
     private String reason;
 
-    public Decision() {}
+    Decision() {}
 
     public boolean isAllowed() {
       return allowed;

--- a/opa-gson/src/test/java/io/github/open_policy_agent/opa/gson/GsonAnnotationIntrospectorTest.java
+++ b/opa-gson/src/test/java/io/github/open_policy_agent/opa/gson/GsonAnnotationIntrospectorTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import io.github.open_policy_agent.opa.mapper.AnnotationIntrospector;
-import io.github.open_policy_agent.opa.mapper.AnnotationIntrospector.Visibility;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -121,7 +120,7 @@ class GsonAnnotationIntrospectorTest {
   // --- findCreatorParamName ---
 
   static class WithCreator {
-    public WithCreator(String foo, String bar) {}
+    WithCreator(String foo, String bar) {}
   }
 
   @Test
@@ -130,7 +129,7 @@ class GsonAnnotationIntrospectorTest {
     // @Target is FIELD, METHOD only), and Gson's annotation set has no @JsonCreator analogue.
     // Constructor injection is configured via InstanceCreator on the GsonBuilder, not via
     // annotations, so this method has no annotation to read.
-    Constructor<?> ctor = WithCreator.class.getConstructor(String.class, String.class);
+    Constructor<?> ctor = WithCreator.class.getDeclaredConstructor(String.class, String.class);
     Parameter[] params = ctor.getParameters();
     assertThat(introspector.findCreatorParamName(params[0])).isNull();
     assertThat(introspector.findCreatorParamName(params[1])).isNull();

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/MetricsModule.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/MetricsModule.java
@@ -1,7 +1,6 @@
 package io.github.open_policy_agent.opa.jackson;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.github.open_policy_agent.opa.metrics.Metrics;
 import io.github.open_policy_agent.opa.metrics.SimpleMetrics;

--- a/opa-jackson/src/test/java/io/github/open_policy_agent/opa/jackson/JacksonAnnotationIntrospectorTest.java
+++ b/opa-jackson/src/test/java/io/github/open_policy_agent/opa/jackson/JacksonAnnotationIntrospectorTest.java
@@ -129,12 +129,12 @@ class JacksonAnnotationIntrospectorTest {
   // --- findCreatorParamName ---
 
   static class WithCreator {
-    public WithCreator(@JsonProperty("foo") String foo, String bar) {}
+    WithCreator(@JsonProperty("foo") String foo, String bar) {}
   }
 
   @Test
   void findCreatorParamName_readsAnnotationOnParameter() throws NoSuchMethodException {
-    Constructor<?> ctor = WithCreator.class.getConstructor(String.class, String.class);
+    Constructor<?> ctor = WithCreator.class.getDeclaredConstructor(String.class, String.class);
     Parameter[] params = ctor.getParameters();
     assertThat(introspector.findCreatorParamName(params[0])).isEqualTo("foo");
     // Unannotated parameter -> null.
@@ -145,29 +145,29 @@ class JacksonAnnotationIntrospectorTest {
 
   static class CreatorPropsCtor {
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public CreatorPropsCtor(@JsonProperty("x") String x) {}
+    CreatorPropsCtor(@JsonProperty("x") String x) {}
   }
 
   static class CreatorDelegatingCtor {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public CreatorDelegatingCtor(String x) {}
+    CreatorDelegatingCtor(String x) {}
   }
 
   static class NoCreatorCtor {
-    public NoCreatorCtor(String x) {}
+    NoCreatorCtor(String x) {}
   }
 
   @Test
   void isJsonCreator_constructor_acceptsPropertiesNotDelegating() throws Exception {
     assertThat(
             introspector.isJsonCreator(
-                CreatorPropsCtor.class.getConstructor(String.class)))
+                CreatorPropsCtor.class.getDeclaredConstructor(String.class)))
         .isTrue();
     assertThat(
             introspector.isJsonCreator(
-                CreatorDelegatingCtor.class.getConstructor(String.class)))
+                CreatorDelegatingCtor.class.getDeclaredConstructor(String.class)))
         .isFalse();
-    assertThat(introspector.isJsonCreator(NoCreatorCtor.class.getConstructor(String.class)))
+    assertThat(introspector.isJsonCreator(NoCreatorCtor.class.getDeclaredConstructor(String.class)))
         .isFalse();
   }
 


### PR DESCRIPTION
Closes #92 

## Summary

Fixes the remaining long-tail Checkstyle items from #92.

- Remove redundant `public` modifiers from test helper constructors
- Remove unused and redundant imports
- Reflow long builtin annotation descriptions that exceeded line length
- Add `hashCode()` implementations for `RegoSet`, `RegoNull`, and `RegoUndefined`
- Add regression coverage for Rego value `equals`/`hashCode` behavior
- Remove empty blocks and add the missing switch default
