### PR TITLE
ci: add zizmor GitHub Actions security linting

### DIFF
--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -14,14 +14,14 @@ jobs:
     name: Test and Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: "17"
           distribution: "corretto"
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
       - run: ./gradlew test checkstyleMain checkstyleTest pmdMain pmdTest
@@ -31,14 +31,14 @@ jobs:
     needs: test-and-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: "17"
           distribution: "corretto"
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
       - name: Publish to Maven Central
@@ -57,7 +57,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set TAG_NAME

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,10 +4,16 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check-changes:
     name: Check what files changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       opa-evaluator: ${{ steps.changes.outputs.opa-evaluator }}
       opa-jackson: ${{ steps.changes.outputs.opa-jackson }}
@@ -15,15 +21,21 @@ jobs:
       opa-builtins: ${{ steps.changes.outputs.opa-builtins }}
       opa-slf4j: ${{ steps.changes.outputs.opa-slf4j }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download OPA
-        uses: open-policy-agent/setup-opa@v2
+        uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
         with:
           version: latest
 
       - name: Check for file changes
         id: changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -e
 
@@ -33,8 +45,8 @@ jobs:
           echo "opa-builtins=true" >> $GITHUB_OUTPUT
           echo "opa-slf4j=true" >> $GITHUB_OUTPUT
 
-          if ! curl -s -o changed_files.json -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"; then
+          if ! curl -s -o changed_files.json -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}/files"; then
             echo "Failed to fetch changed files, defaulting to running all checks"
             exit 0
           fi
@@ -67,31 +79,48 @@ jobs:
           echo "opa-services=${opa_services}" >> $GITHUB_OUTPUT
           echo "opa-builtins=${opa_builtins}" >> $GITHUB_OUTPUT
           echo "opa-slf4j=${opa_slf4j}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  gh-actions-lint:
+    name: GitHub Actions Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # zizmor-action uploads its SARIF results to the Security tab
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
 
   lint:
     name: Checkstyle & PMD
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - run: ./gradlew checkstyleMain checkstyleTest pmdMain pmdTest
 
   validate-pom:
     name: Validate Publish POMs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Generate POMs
         run: ./gradlew generatePomFileForMavenPublication
       # Maven's built-in model validator catches the rule that bit us at v0.1.0:
@@ -115,12 +144,14 @@ jobs:
     if: needs.check-changes.outputs.opa-evaluator == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - run: ./gradlew :opa-evaluator:test
 
   test-opa-jackson:
@@ -128,12 +159,14 @@ jobs:
     if: needs.check-changes.outputs.opa-jackson == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - run: ./gradlew :opa-jackson:test
 
   test-opa-services:
@@ -141,12 +174,14 @@ jobs:
     if: needs.check-changes.outputs.opa-services == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - run: ./gradlew :opa-services:test
 
   test-opa-builtins:
@@ -154,12 +189,14 @@ jobs:
     if: needs.check-changes.outputs.opa-builtins == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - run: ./gradlew :opa-builtins:test
 
   test-opa-slf4j:
@@ -167,12 +204,14 @@ jobs:
     if: needs.check-changes.outputs.opa-slf4j == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - run: ./gradlew :opa-slf4j:test
 
   pr-check-summary:
@@ -180,6 +219,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check-changes
+      - gh-actions-lint
       - lint
       - validate-pom
       - test-opa-evaluator
@@ -189,16 +229,20 @@ jobs:
       - test-opa-slf4j
     if: always()
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download OPA
-        uses: open-policy-agent/setup-opa@v2
+        uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
         with:
           version: latest
 
       - name: Check job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo '${{ toJSON(needs) }}' > input.json
+          printf '%s' "$NEEDS_JSON" > input.json
 
           opa eval -d .github/workflows/pull-request.yml \
             --input=input.json \


### PR DESCRIPTION
## What

Adds [zizmor](https://docs.zizmor.sh/) static analysis of our GitHub Actions workflows, mirroring the setup in [open-policy-agent/opa](https://github.com/open-policy-agent/opa).

A new `gh-actions-lint` job runs `zizmorcore/zizmor-action` (pinned to v0.5.7, matching OPA) on every PR and is wired into the `pr-check-summary` gate so it is a required check.

## Findings fixed

Enabling zizmor surfaced findings on the existing workflows, all resolved here so the check passes cleanly:

- **`unpinned-uses`** — hash-pinned every action to a full commit SHA (with `# vX.Y.Z` comments; Dependabot still bumps them).
- **`excessive-permissions`** — added a least-privilege top-level `permissions: contents: read`, with per-job grants where needed (`pull-requests: read` for the changed-files check, `security-events: write` scoped to the zizmor job for its SARIF upload).
- **`artipacked`** — set `persist-credentials: false` on all `actions/checkout` steps.
- **`template-injection`** — moved `github.*` / `toJSON(needs)` context out of `run:` blocks into `env:` vars.

## Verification

`zizmor` reports **no findings** locally against both workflow files.

> Note: the zizmor job uploads SARIF to the Security tab (`advanced-security: true`, as in OPA). On PRs from forks, `GITHUB_TOKEN` is read-only so that upload may 403 — if that becomes an issue we can switch the step to `advanced-security: false` + `annotations: true`.
