### PR TITLE
ci: add dependency review to PRs

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,29 @@
+name: Dependency Submission
+
+# Submits the resolved Gradle dependency graph to GitHub's Dependency Graph.
+# This populates the baseline for `dependency-review` on pull requests and
+# enables Dependabot alerts for transitive dependencies.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-submission:
+    name: Submit Dependency Graph
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # dependency-submission writes the graph snapshot to the repo
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -95,6 +95,25 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
 
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      # Diffs the dependency graph between the PR base and head, failing on newly
+      # introduced vulnerabilities or disallowed licenses. Relies on the baseline
+      # graph submitted by dependency-submission.yml on pushes to main.
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
   lint:
     name: Checkstyle & PMD
     runs-on: ubuntu-latest
@@ -220,6 +239,7 @@ jobs:
     needs:
       - check-changes
       - gh-actions-lint
+      - dependency-review
       - lint
       - validate-pom
       - test-opa-evaluator


### PR DESCRIPTION
## What

Adds supply-chain dependency scanning to CI:

- **`dependency-review` job** in the PR check using `actions/dependency-review-action`, gated on `high`+ severity advisories, posting a summary comment on failure. Wired into the existing `pr-check-summary` gate.
- **`dependency-submission.yml`** workflow that submits the resolved Gradle dependency graph to GitHub's Dependency Graph on pushes to `main`. This gives the PR review a baseline to diff against and enables Dependabot alerts for transitive dependencies.

## Why

We publish artifacts to Maven Central, so newly introduced vulnerable/disallowed dependencies should be caught at PR time.

## Notes

- Actions are hash-pinned to match the repo's zizmor policy.
- The dependency-review baseline lags one merge: on the first PR after this lands, the base graph won't exist until `dependency-submission.yml` has run once on `main`. It self-corrects after that.
- Requires *Settings -> Code security -> Dependency graph* enabled (default for public repos).
