### PR TITLE
chore: add CODEOWNERS to auto-request maintainer reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for java-opa-sdk.
+# GitHub automatically requests a review from these owners on every pull request.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @open-policy-agent/java-opa-maintainers


### PR DESCRIPTION
## What

Adds a `.github/CODEOWNERS` file assigning `@open-policy-agent/java-opa-maintainers` as the owner of all files (`*`).

## Why

So that the maintainers team is automatically requested for review on every pull request, rather than relying on manual reviewer assignment.

## Notes

- Requires the `java-opa-maintainers` team to exist in the org and have write access to the repo for GitHub to honor the entry.
- Optionally pair with branch protection's "Require review from Code Owners" to enforce (not just request) maintainer approval before merge.
