### PR TITLE
Auto-discover plugins in status report

### DIFF
--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/PluginManager.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/PluginManager.java
@@ -5,8 +5,11 @@ import io.github.open_policy_agent.opa.logging.Logger;
 import io.github.open_policy_agent.opa.storage.Store;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -68,6 +71,10 @@ public class PluginManager {
 
   public Plugin getPlugin(String name) {
     return plugins.get(name);
+  }
+
+  public Set<String> getPluginNames() {
+    return Collections.unmodifiableSet(new HashSet<>(plugins.keySet()));
   }
 
   public String getId() {

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
@@ -185,10 +185,9 @@ public final class StatusPlugin implements Plugin {
 
       // Add plugin statuses (only for registered plugins)
       ObjectNode plugins = MAPPER.createObjectNode();
-      addPluginStatusIfRegistered(plugins, "bundles");
-      addPluginStatusIfRegistered(plugins, "decision_logs");
-      addPluginStatusIfRegistered(plugins, "status");
-      addPluginStatusIfRegistered(plugins, "discovery");
+      for (String pluginName : manager.getPluginNames()) {
+        addPluginStatusIfRegistered(plugins, pluginName);
+      }
       report.set("plugins", plugins);
 
       return report;

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
@@ -183,9 +183,14 @@ public final class StatusPlugin implements Plugin {
       }
       report.set("bundles", bundles);
 
-      // Add plugin statuses (only for registered plugins)
+      // Add plugin statuses (only for registered plugins). The "services" plugin holds REST
+      // service clients rather than a status-reporting plugin, so it is excluded to match the
+      // previous behavior and Go OPA, where it does not appear in the status report.
       ObjectNode plugins = MAPPER.createObjectNode();
       for (String pluginName : manager.getPluginNames()) {
+        if ("services".equals(pluginName)) {
+          continue;
+        }
         addPluginStatusIfRegistered(plugins, pluginName);
       }
       report.set("plugins", plugins);

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
@@ -273,6 +273,35 @@ class StatusPluginTest {
   }
 
   @Test
+  void statusReport_excludesServicesPlugin() throws Exception {
+    Config.StatusConfig status = new Config.StatusConfig().setConsole(true);
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    // The "services" plugin reports an OK status but must not surface in the report.
+    manager.registerPlugin("services", new NoopPlugin());
+    manager.updatePluginStatus("services", PluginManager.Status.OK);
+    manager.registerPlugin("custom_plugin", new NoopPlugin());
+    manager.updatePluginStatus("custom_plugin", PluginManager.Status.OK);
+
+    StatusPlugin plugin = new StatusPlugin();
+    plugin = (StatusPlugin) plugin.initialize(manager);
+
+    ObjectNode report = buildStatusReport(plugin);
+    ObjectNode plugins = (ObjectNode) report.get("plugins");
+
+    assertFalse(plugins.has("services"));
+    assertTrue(plugins.has("custom_plugin"));
+  }
+
+  @Test
   void statusReport_sendsToService() throws Exception {
     Config.StatusConfig status =
         new Config.StatusConfig().setService("test-service").setConsole(false);

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
@@ -3,6 +3,7 @@ package io.github.open_policy_agent.opa.plugins;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -246,6 +247,32 @@ class StatusPluginTest {
   }
 
   @Test
+  void statusReport_includesCustomRegisteredPlugin() throws Exception {
+    Config.StatusConfig status = new Config.StatusConfig().setConsole(true);
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    manager.registerPlugin("custom_plugin", new NoopPlugin());
+    manager.updatePluginStatus("custom_plugin", PluginManager.Status.OK);
+
+    StatusPlugin plugin = new StatusPlugin();
+    plugin = (StatusPlugin) plugin.initialize(manager);
+
+    ObjectNode report = buildStatusReport(plugin);
+    ObjectNode plugins = (ObjectNode) report.get("plugins");
+
+    assertTrue(plugins.has("custom_plugin"));
+    assertEquals("OK", plugins.get("custom_plugin").asText());
+  }
+
+  @Test
   void statusReport_sendsToService() throws Exception {
     Config.StatusConfig status =
         new Config.StatusConfig().setService("test-service").setConsole(false);
@@ -323,5 +350,34 @@ class StatusPluginTest {
       assertTrue(report.has("id"));
       assertEquals("prod-us-west-1-opa-123", report.get("id").asText());
     }
+  }
+
+  private ObjectNode buildStatusReport(StatusPlugin plugin) throws Exception {
+    java.lang.reflect.Field statusField = StatusPlugin.class.getDeclaredField("status");
+    statusField.setAccessible(true);
+    StatusPlugin.Status statusReporter = (StatusPlugin.Status) statusField.get(plugin);
+
+    java.lang.reflect.Method buildStatusMethod =
+        StatusPlugin.Status.class.getDeclaredMethod("buildStatusReport");
+    buildStatusMethod.setAccessible(true);
+    return (ObjectNode) buildStatusMethod.invoke(statusReporter);
+  }
+
+  private static class NoopPlugin implements Plugin {
+    @Override
+    public Set<String> validate(PluginManager manager) {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Plugin initialize(PluginManager manager) {
+      return this;
+    }
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void stop() {}
   }
 }


### PR DESCRIPTION
Fixes #82

### Summary
- Add a `PluginManager` accessor for the currently registered plugin names.
- Build status report plugin statuses by iterating registered plugins instead of a hardcoded built-in list.
- Cover custom registered plugins appearing in the status report.

### Verification
- `./gradlew :opa-services:test`
- `./gradlew :opa-services:check`
- `git diff --check`

### Disclosure
This contribution was prepared with AI assistance and reviewed before submission.
