### PR TITLE
Add manual trigger mode for bundle refresh

### DIFF
--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -327,32 +327,9 @@ public class Config {
   }
 
   public static class BundleConfig {
-    /** Default maximum bundle size (compressed download and decompressed contents): 512 MB. */
-    public static final long DEFAULT_MAX_SIZE_BYTES = 512L * 1024 * 1024;
-
     private PollingConfig polling;
     private String service;
     private String resource;
-
-    /**
-     * Maximum bundle size in bytes, applied both to the compressed HTTP download and to the
-     * decompressed tarball contents. Defaults to {@link #DEFAULT_MAX_SIZE_BYTES} (512 MB).
-     *
-     * <p><strong>Effective ceiling differs by path</strong>, because both paths buffer payloads
-     * into a Java {@code byte[]}, whose maximum length is {@link Integer#MAX_VALUE} (~2 GB):
-     *
-     * <ul>
-     *   <li><strong>HTTP download:</strong> The entire response is buffered in a single {@code
-     *       byte[]}, so the effective limit is capped at {@code Integer.MAX_VALUE} (~2 GB).
-     *       Configured values above that are silently clamped to {@code Integer.MAX_VALUE} on the
-     *       download path.
-     *   <li><strong>Decompressed tarball contents:</strong> The cumulative budget is tracked as a
-     *       {@code long} and may exceed 2 GB. Only each individual entry is bounded by the {@code
-     *       byte[]} ceiling (~2 GB per entry); the sum across all entries can be larger.
-     * </ul>
-     */
-    @JsonProperty("max_size_bytes")
-    private long maxSizeBytes = DEFAULT_MAX_SIZE_BYTES;
 
     public PollingConfig getPolling() {
       return polling;
@@ -381,20 +358,6 @@ public class Config {
       return this;
     }
 
-    public long getMaxSizeBytes() {
-      return maxSizeBytes;
-    }
-
-    /**
-     * Set the maximum bundle size in bytes. Note that the HTTP download enforcement is capped at
-     * {@link Integer#MAX_VALUE} (~2 GB); values above that are clamped on the download path. See
-     * {@link #maxSizeBytes} for details.
-     */
-    public BundleConfig setMaxSizeBytes(long maxSizeBytes) {
-      this.maxSizeBytes = maxSizeBytes;
-      return this;
-    }
-
     @Override
     public String toString() {
       return "BundleConfig{"
@@ -406,8 +369,6 @@ public class Config {
           + ", resource='"
           + resource
           + '\''
-          + ", maxSizeBytes="
-          + maxSizeBytes
           + '}';
     }
   }

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -333,7 +333,14 @@ public class Config {
     private PollingConfig polling;
     private String service;
     private String resource;
+
+    @JsonProperty("trigger")
+    private Trigger trigger = Trigger.PERIODIC;
+
     public static final long DEFAULT_MAX_SIZE_BYTES = 1024L * 1024L * 1024L;
+
+    @JsonProperty("max_size_bytes")
+    private long maxSizeBytes = DEFAULT_MAX_SIZE_BYTES;
 
     public PollingConfig getPolling() {
       return polling;
@@ -362,18 +369,40 @@ public class Config {
       return this;
     }
 
+    public Trigger getTrigger() {
+      return trigger;
+    }
+
+    public BundleConfig setTrigger(Trigger trigger) {
+      this.trigger = trigger;
+      return this;
+    }
+
+    public long getMaxSizeBytes() {
+      return maxSizeBytes;
+    }
+
+    public BundleConfig setMaxSizeBytes(long maxSizeBytes) {
+      this.maxSizeBytes = maxSizeBytes;
+      return this;
+    }
+
     @Override
     public String toString() {
       return "BundleConfig{"
-          + "polling="
-          + polling
-          + ", service='"
-          + service
-          + '\''
-          + ", resource='"
-          + resource
-          + '\''
-          + '}';
+              + "polling="
+              + polling
+              + ", service='"
+              + service
+              + '\''
+              + ", resource='"
+              + resource
+              + '\''
+              + ", trigger="
+              + trigger
+              + ", maxSizeBytes="
+              + maxSizeBytes
+              + '}';
     }
   }
 

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -325,11 +325,15 @@ public class Config {
           + '}';
     }
   }
-
+    public enum Trigger {
+        PERIODIC,
+        MANUAL
+    }
   public static class BundleConfig {
     private PollingConfig polling;
     private String service;
     private String resource;
+    public static final long DEFAULT_MAX_SIZE_BYTES = 1024L * 1024L * 1024L;
 
     public PollingConfig getPolling() {
       return polling;

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -72,6 +72,10 @@ public abstract class BundleDownloader {
     return this;
   }
 
+  public Config.Trigger getTrigger() {
+    return trigger;
+  }
+
   /**
    * Construct a BundleDownloader.
    *
@@ -169,6 +173,10 @@ public abstract class BundleDownloader {
   public BundleDownloader setMaxSizeBytes(long maxSizeBytes) {
     this.maxSizeBytes = maxSizeBytes;
     return this;
+  }
+
+  public long getMaxSizeBytes() {
+    return maxSizeBytes;
   }
 
   /**

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -54,6 +54,7 @@ public abstract class BundleDownloader {
   protected String resource;
   protected Config.PollingConfig polling;
   protected Config.Trigger trigger = Config.Trigger.PERIODIC;
+  private ScheduledExecutorService scheduler;
   protected String etag;
   protected long lastModifiedTime = 0;
   protected long maxSizeBytes = Config.BundleConfig.DEFAULT_MAX_SIZE_BYTES;
@@ -193,8 +194,10 @@ public abstract class BundleDownloader {
    * @param scheduler the scheduler to use for periodic downloads
    * @return a future that completes when the initial bundle is downloaded and activated
    */
-  public CompletableFuture<Void> startPolling(ScheduledExecutorService scheduler) {
 
+
+  public CompletableFuture<Void> startPolling(ScheduledExecutorService scheduler) {
+    this.scheduler = scheduler;
     if (trigger == Config.Trigger.MANUAL) {
       manager.getLogger().info(
               "Bundle '%s': Manual trigger mode enabled; waiting for refresh()", name);
@@ -212,15 +215,18 @@ public abstract class BundleDownloader {
 
 
 
-    scheduler.schedule(this::downloadBundle, 0, TimeUnit.SECONDS);
+    scheduler.schedule(() -> downloadBundle(initialActivation), 0, TimeUnit.SECONDS);
     scheduleNextPoll(scheduler, minDelay, maxDelay);
 
     return initialActivation;
   }
 
   public CompletableFuture<Void> refresh() {
-    downloadBundle();
-    return initialActivation;
+    CompletableFuture<Void> refreshFuture = new CompletableFuture<>();
+
+    scheduler.execute(() -> downloadBundle(refreshFuture));
+
+    return refreshFuture;
   }
 
   // Re-schedules the next download with a uniformly random delay in [minDelay, maxDelay],
@@ -235,7 +241,7 @@ public abstract class BundleDownloader {
       scheduler.schedule(
           () -> {
             try {
-              downloadBundle();
+              downloadBundle(initialActivation);
             } catch (Exception e) {
               // downloadBundle() handles its own logging; swallow so the chain keeps polling.
               // Only Exception is caught here — Errors (OOM, etc.) propagate and let the
@@ -258,7 +264,7 @@ public abstract class BundleDownloader {
    * <p>Handles HTTP/HTTPS downloads with ETag caching, file:// URIs, and filesystem paths. Calls
    * {@link #activateBundle(byte[])} when new bundle data is available.
    */
-  protected void downloadBundle() {
+  protected void downloadBundle(CompletableFuture<Void> future) {
     try {
       Config.ServiceConfig serviceConfig = manager.getConfig().getService(service);
       if (serviceConfig == null) {
@@ -284,17 +290,17 @@ public abstract class BundleDownloader {
 
         // Handle file:// URIs
         if ("file".equalsIgnoreCase(uri.getScheme())) {
-          handleFileDownload(Paths.get(uri));
+          handleFileDownload(Paths.get(uri), future);
           return;
         }
 
         // Handle HTTP/HTTPS URIs
-        handleHttpDownload(uri);
+        handleHttpDownload(uri, future);
       } else {
         // It's a file path (relative or absolute)
         Path basePath = Paths.get(baseUrl);
         Path filePath = basePath.resolve(resource);
-        handleFileDownload(filePath);
+        handleFileDownload(filePath, future);
       }
 
     } catch (Exception e) {
@@ -310,12 +316,13 @@ public abstract class BundleDownloader {
    *
    * @param filePath the path to the file
    */
-  private void handleFileDownload(Path filePath) throws IOException {
+  private void handleFileDownload(Path filePath, CompletableFuture<Void> future) throws IOException{
     FileTime currentModTime = Files.getLastModifiedTime(filePath);
     long currentModTimeMillis = currentModTime.toMillis();
 
     if (lastModifiedTime != 0 && lastModifiedTime == currentModTimeMillis) {
       manager.getLogger().debug("Bundle '%s': File not modified, skipping activation", name);
+      future.complete(null);
       if (!initialActivation.isDone()) {
         initialActivation.complete(null);
       }
@@ -325,6 +332,8 @@ public abstract class BundleDownloader {
     byte[] bundleData = Files.readAllBytes(filePath);
     activateBundle(bundleData);
     lastModifiedTime = currentModTimeMillis;
+
+    future.complete(null);
 
     if (!initialActivation.isDone()) {
       initialActivation.complete(null);
@@ -336,7 +345,7 @@ public abstract class BundleDownloader {
    *
    * @param uri the URI to download from
    */
-  private void handleHttpDownload(URI uri) {
+  private void handleHttpDownload(URI uri, CompletableFuture<Void> future) {
     HttpRequest.Builder requestBuilder =
         HttpRequest.newBuilder()
             .uri(uri)
@@ -363,6 +372,8 @@ public abstract class BundleDownloader {
                         ? throwable.getCause()
                         : throwable;
                 manager.getLogger().error("Bundle '%s': Download error: %s", name, cause.getMessage());
+                future.completeExceptionally(cause);
+
                 if (!initialActivation.isDone()) {
                   initialActivation.completeExceptionally(cause);
                 }
@@ -371,6 +382,8 @@ public abstract class BundleDownloader {
 
               if (response.statusCode() == 304) {
                 manager.getLogger().debug("Bundle '%s': Not modified (ETag match)", name);
+                future.complete(null);
+
                 if (!initialActivation.isDone()) {
                   initialActivation.complete(null);
                 }
@@ -382,8 +395,12 @@ public abstract class BundleDownloader {
                 if (!isAcceptableContentType(contentType)) {
                   String errorMsg = "Unexpected Content-Type: '" + contentType + "'";
                   manager.getLogger().error("Bundle '%s': %s", name, errorMsg);
+                  RuntimeException ex = new RuntimeException(errorMsg);
+
+                  future.completeExceptionally(ex);
+
                   if (!initialActivation.isDone()) {
-                    initialActivation.completeExceptionally(new RuntimeException(errorMsg));
+                    initialActivation.completeExceptionally(ex);
                   }
                   return;
                 }
@@ -392,19 +409,27 @@ public abstract class BundleDownloader {
                   activateBundle(response.body());
                 } catch (Exception e) {
                   manager.getLogger().error("Bundle '%s': Activation failed: %s", name, e.getMessage());
+                  future.completeExceptionally(e);
+
                   if (!initialActivation.isDone()) {
                     initialActivation.completeExceptionally(e);
                   }
                   return;
                 }
+                future.complete(null);
+
                 if (!initialActivation.isDone()) {
                   initialActivation.complete(null);
                 }
               } else {
                 String errorMsg = "Download failed with status " + response.statusCode();
                 manager.getLogger().error("Bundle '%s': %s", name, errorMsg);
+                RuntimeException ex = new RuntimeException(errorMsg);
+
+                future.completeExceptionally(ex);
+
                 if (!initialActivation.isDone()) {
-                  initialActivation.completeExceptionally(new RuntimeException(errorMsg));
+                  initialActivation.completeExceptionally(ex);
                 }
               }
             });

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -53,6 +53,7 @@ public abstract class BundleDownloader {
   protected String service;
   protected String resource;
   protected Config.PollingConfig polling;
+  protected Config.Trigger trigger = Config.Trigger.PERIODIC;
   protected String etag;
   protected long lastModifiedTime = 0;
   protected long maxSizeBytes = Config.BundleConfig.DEFAULT_MAX_SIZE_BYTES;
@@ -65,6 +66,11 @@ public abstract class BundleDownloader {
           "application/octet-stream",
           "binary/octet-stream",
           "application/x-tar");
+
+  public BundleDownloader setTrigger(Config.Trigger trigger) {
+    this.trigger = trigger;
+    return this;
+  }
 
   /**
    * Construct a BundleDownloader.
@@ -180,6 +186,13 @@ public abstract class BundleDownloader {
    * @return a future that completes when the initial bundle is downloaded and activated
    */
   public CompletableFuture<Void> startPolling(ScheduledExecutorService scheduler) {
+
+    if (trigger == Config.Trigger.MANUAL) {
+      manager.getLogger().info(
+              "Bundle '%s': Manual trigger mode enabled; waiting for refresh()", name);
+      return initialActivation;
+    }
+
     int minDelay =
         (polling != null && polling.getMinDelaySeconds() != null)
             ? polling.getMinDelaySeconds()
@@ -189,9 +202,16 @@ public abstract class BundleDownloader {
             ? polling.getMaxDelaySeconds()
             : 120;
 
+
+
     scheduler.schedule(this::downloadBundle, 0, TimeUnit.SECONDS);
     scheduleNextPoll(scheduler, minDelay, maxDelay);
 
+    return initialActivation;
+  }
+
+  public CompletableFuture<Void> refresh() {
+    downloadBundle();
     return initialActivation;
   }
 

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundlePlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundlePlugin.java
@@ -73,13 +73,12 @@ public final class BundlePlugin implements Plugin {
         ServicePlugin.Service svc =
             servicePlugin == null ? null : servicePlugin.getService(bundleConfig.getService());
 
-        Bundle bundle =
+        plugin.bundles.put(
+            name,
             new Bundle(name, manager, svc)
                 .setService(bundleConfig.getService())
                 .setResource(bundleConfig.getResource())
-                .setPolling(bundleConfig.getPolling());
-        bundle.setMaxSizeBytes(bundleConfig.getMaxSizeBytes());
-        plugin.bundles.put(name, bundle);
+                .setPolling(bundleConfig.getPolling()));
       }
     }
 
@@ -184,7 +183,7 @@ public final class BundlePlugin implements Plugin {
     protected void activateBundle(byte[] bundleData) {
       try {
         // Load bundle using TarballBundleLoader
-        TarballBundleLoader loader = new TarballBundleLoader(name, bundleData, maxSizeBytes);
+        TarballBundleLoader loader = new TarballBundleLoader(name, bundleData);
         loader.load(manager.getStore());
 
         manager.getLogger().info("Bundle '%s': Activated", name);

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundlePlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundlePlugin.java
@@ -45,6 +45,10 @@ public final class BundlePlugin implements Plugin {
           errors.add("Bundle '" + name + "' has missing or empty resource path");
         }
         errors.addAll(BundleDownloader.validatePolling(bundle.getPolling(), "Bundle '" + name + "'"));
+        if (bundle.getTrigger() == Config.Trigger.MANUAL && bundle.getPolling() != null) {
+          errors.add(
+                  "Bundle '" + name + "' cannot specify polling when trigger is MANUAL");
+        }
       }
     }
     return errors;
@@ -78,7 +82,9 @@ public final class BundlePlugin implements Plugin {
             new Bundle(name, manager, svc)
                 .setService(bundleConfig.getService())
                 .setResource(bundleConfig.getResource())
-                .setPolling(bundleConfig.getPolling()));
+                .setPolling(bundleConfig.getPolling()))
+                .setTrigger(bundleConfig.getTrigger())
+                .setMaxSizeBytes(bundleConfig.getMaxSizeBytes());
       }
     }
 
@@ -177,6 +183,26 @@ public final class BundlePlugin implements Plugin {
 
     public Config.PollingConfig getPolling() {
       return polling;
+    }
+
+    @Override
+    public Bundle setTrigger(Config.Trigger trigger) {
+      super.setTrigger(trigger);
+      return this;
+    }
+
+    public Config.Trigger getTrigger() {
+      return trigger;
+    }
+
+    @Override
+    public Bundle setMaxSizeBytes(long maxSizeBytes) {
+      super.setMaxSizeBytes(maxSizeBytes);
+      return this;
+    }
+
+    public long getMaxSizeBytes() {
+      return maxSizeBytes;
     }
 
     @Override

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundlePlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundlePlugin.java
@@ -47,7 +47,7 @@ public final class BundlePlugin implements Plugin {
         errors.addAll(BundleDownloader.validatePolling(bundle.getPolling(), "Bundle '" + name + "'"));
         if (bundle.getTrigger() == Config.Trigger.MANUAL && bundle.getPolling() != null) {
           errors.add(
-                  "Bundle '" + name + "' cannot specify polling when trigger is MANUAL");
+                  "Bundle '" + name + "' cannot specify polling when trigger is manual");
         }
       }
     }
@@ -78,14 +78,13 @@ public final class BundlePlugin implements Plugin {
             servicePlugin == null ? null : servicePlugin.getService(bundleConfig.getService());
 
         plugin.bundles.put(
-            name,
-            new Bundle(name, manager, svc)
-                .setService(bundleConfig.getService())
-                .setResource(bundleConfig.getResource())
-                .setPolling(bundleConfig.getPolling()))
-                .setTrigger(bundleConfig.getTrigger())
-                .setMaxSizeBytes(bundleConfig.getMaxSizeBytes());
-      }
+                name,
+                new Bundle(name, manager, svc)
+                        .setService(bundleConfig.getService())
+                        .setResource(bundleConfig.getResource())
+                        .setPolling(bundleConfig.getPolling())
+                        .setTrigger(bundleConfig.getTrigger())
+                        .setMaxSizeBytes(bundleConfig.getMaxSizeBytes()));      }
     }
 
     return plugin;
@@ -100,11 +99,19 @@ public final class BundlePlugin implements Plugin {
     // Set initial status so wait logic knows plugin is registered
     manager.updatePluginStatus("bundles", PluginManager.Status.NOT_READY);
 
+    bundles.values().forEach(bundle -> bundle.startPolling(scheduler));
+
     // Collect all initial activation futures
     CompletableFuture<?>[] activationFutures =
         bundles.values().stream()
-            .map(bundle -> bundle.startPolling(scheduler))
-            .toArray(CompletableFuture[]::new);
+                .filter(bundle -> bundle.getTrigger() == Config.Trigger.PERIODIC)
+                .map(Bundle::getInitialActivation)
+                .toArray(CompletableFuture[]::new);
+
+    if (activationFutures.length == 0) {
+      manager.updatePluginStatus("bundles", PluginManager.Status.OK);
+      return;
+    }
 
     // Wait for all bundles to complete initial activation
     CompletableFuture.allOf(activationFutures)

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundlePluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundlePluginTest.java
@@ -46,6 +46,62 @@ class BundlePluginTest {
   }
 
   @Test
+  void validate_manualTriggerWithPolling_returnsError() {
+    Config.BundleConfig bundle =
+            new Config.BundleConfig()
+                    .setService("test-service")
+                    .setResource("/bundles/test.tar.gz")
+                    .setTrigger(Config.Trigger.MANUAL)
+                    .setPolling(
+                            new Config.PollingConfig()
+                                    .setMinDelaySeconds(60)
+                                    .setMaxDelaySeconds(120));
+
+    config.setBundles(Collections.singletonMap("test-bundle", bundle));
+
+    manager =
+            new PluginManager.Builder()
+                    .withId("test-opa")
+                    .withStore(store)
+                    .withConfig(config)
+                    .withLogger(mockLogger)
+                    .build();
+
+    Set<String> errors = new BundlePlugin().validate(manager);
+
+    assertTrue(
+            errors.stream()
+                    .anyMatch(e -> e.contains("cannot specify polling when trigger is manual")));
+  }
+
+  @Test
+  void initialize_manualTrigger_setsTrigger() {
+    Config.BundleConfig bundle =
+            new Config.BundleConfig()
+                    .setService("test-service")
+                    .setResource("/bundles/test.tar.gz")
+                    .setTrigger(Config.Trigger.MANUAL);
+
+    config.setBundles(Collections.singletonMap("test-bundle", bundle));
+
+    manager =
+            new PluginManager.Builder()
+                    .withId("test-opa")
+                    .withStore(store)
+                    .withConfig(config)
+                    .withLogger(mockLogger)
+                    .build();
+
+    BundlePlugin plugin = (BundlePlugin) new BundlePlugin().initialize(manager);
+
+    assertNotNull(plugin.getBundle("test-bundle"));
+    assertEquals(
+            Config.Trigger.MANUAL,
+            plugin.getBundle("test-bundle").getTrigger());
+  }
+
+
+  @Test
   void validate_noBundlesConfigured_returnsNoErrors() {
     manager =
         new PluginManager.Builder()


### PR DESCRIPTION
## Summary

This PR adds support for a manual trigger mode for bundle refresh while preserving the existing periodic polling behavior as the default.

##Issues #65 

## Changes

- Added `Trigger` configuration with `PERIODIC` (default) and `MANUAL` modes.
- Extended `BundleConfig` to support the new `trigger` option.
- Passed the configured trigger from `BundlePlugin` to `BundleDownloader`.
- Updated `BundleDownloader` to skip automatic polling when the trigger is `MANUAL`.
- Added a `refresh()` method to allow bundles to be refreshed on demand.
- Added validation to reject polling configuration when using the manual trigger.
- Added unit tests covering manual trigger configuration and validation.

## Testing

- Verified the project compiles successfully with:
  - `./gradlew :opa-services:compileJava`
- Added unit tests for the new manual trigger functionality.
- Local MTLS integration tests require `openssl`, which is not available in my Windows environment, resulting in an unrelated test initialization failure.