### PR TITLE
Add yaml.is_valid builtin

### DIFF
--- a/opa-builtins/opa-builtins-json/build.gradle.kts
+++ b/opa-builtins/opa-builtins-json/build.gradle.kts
@@ -18,10 +18,17 @@ dependencies {
     // RegoValueModule (auto-registered via Jackson SPI) provides (de)serializers for the AST
     // types so they don't need to carry annotations.
     runtimeOnly(project(":opa-jackson"))
+
+    testImplementation("org.junit.jupiter:junit-jupiter:6.1.1")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.1")
 }
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/opa-builtins/opa-builtins-json/build.gradle.kts
+++ b/opa-builtins/opa-builtins-json/build.gradle.kts
@@ -19,8 +19,8 @@ dependencies {
     // types so they don't need to carry annotations.
     runtimeOnly(project(":opa-jackson"))
 
-    testImplementation("org.junit.jupiter:junit-jupiter:6.1.1")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.1.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.2")
 }
 
 java {

--- a/opa-builtins/opa-builtins-json/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/JsonBuiltins.java
+++ b/opa-builtins/opa-builtins-json/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/JsonBuiltins.java
@@ -123,6 +123,7 @@ public class JsonBuiltins implements BuiltinProvider {
     result.put("json.remove", instance::remove);
     result.put("json.unmarshal", instance::unmarshal);
     result.put("json.verify_schema", instance::verify_schema);
+    result.put("yaml.is_valid", instance::yamlIsValid);
     result.put("yaml.marshal", instance::yamlMarshal);
     result.put("yaml.unmarshal", instance::yamlUnmarshal);
     return result;
@@ -703,6 +704,26 @@ public class JsonBuiltins implements BuiltinProvider {
       return new RegoString(yaml);
     } catch (JsonProcessingException e) {
       throw new BuiltinError("yaml.marshal: " + e.getMessage());
+    }
+  }
+
+  @OpaBuiltin(
+          name = "yaml.is_valid",
+          description = "Verifies the input string is a valid YAML document.",
+          categories = {"encoding"},
+          args = {@OpaType(type = "string", name = "x", description = "a YAML string")},
+          result =
+          @OpaType(
+                  name = "result",
+                  description = "`true` if `x` is valid YAML, `false` otherwise"))
+  public RegoBoolean yamlIsValid(EvaluationContext ctx, RegoValue[] args) {
+    String yamlInput = getArg(args, 0, RegoString.class).getValue();
+
+    try {
+      YAML_MAPPER.readTree(yamlInput);
+      return RegoBoolean.TRUE;
+    } catch (JsonProcessingException e) {
+      return RegoBoolean.FALSE;
     }
   }
 

--- a/opa-builtins/opa-builtins-json/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/JsonBuiltins.java
+++ b/opa-builtins/opa-builtins-json/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/JsonBuiltins.java
@@ -717,10 +717,12 @@ public class JsonBuiltins implements BuiltinProvider {
                   name = "result",
                   description = "`true` if `x` is valid YAML, `false` otherwise"))
   public RegoBoolean yamlIsValid(EvaluationContext ctx, RegoValue[] args) {
-    String yamlInput = getArg(args, 0, RegoString.class).getValue();
+    if (!(args[0] instanceof RegoString yamlInput)) {
+      return RegoBoolean.FALSE;
+    }
 
     try {
-      YAML_MAPPER.readTree(yamlInput);
+      YAML_MAPPER.readTree(yamlInput.getValue());
       return RegoBoolean.TRUE;
     } catch (JsonProcessingException e) {
       return RegoBoolean.FALSE;

--- a/opa-builtins/opa-builtins-json/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/JsonBuiltinsTest.java
+++ b/opa-builtins/opa-builtins-json/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/JsonBuiltinsTest.java
@@ -30,4 +30,11 @@ class JsonBuiltinsTest {
 
     assertEquals(RegoBoolean.FALSE, builtins.yamlIsValid(null, args));
   }
+
+  @Test
+  void yamlIsValidReturnsFalseForNonStringInput() {
+    RegoValue[] args = {RegoBoolean.TRUE};
+
+    assertEquals(RegoBoolean.FALSE, builtins.yamlIsValid(null, args));
+  }
 }

--- a/opa-builtins/opa-builtins-json/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/JsonBuiltinsTest.java
+++ b/opa-builtins/opa-builtins-json/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/JsonBuiltinsTest.java
@@ -1,0 +1,33 @@
+package io.github.open_policy_agent.opa.ast.builtin.impls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.open_policy_agent.opa.ast.types.RegoBoolean;
+import io.github.open_policy_agent.opa.ast.types.RegoString;
+import io.github.open_policy_agent.opa.ast.types.RegoValue;
+import org.junit.jupiter.api.Test;
+
+class JsonBuiltinsTest {
+
+  private final JsonBuiltins builtins = new JsonBuiltins();
+
+  @Test
+  void registersYamlIsValidBuiltin() {
+    assertTrue(builtins.builtins().containsKey("yaml.is_valid"));
+  }
+
+  @Test
+  void yamlIsValidReturnsTrueForValidYaml() {
+    RegoValue[] args = {new RegoString("name: opa\nvalues:\n  - sdk\n  - java\n")};
+
+    assertEquals(RegoBoolean.TRUE, builtins.yamlIsValid(null, args));
+  }
+
+  @Test
+  void yamlIsValidReturnsFalseForInvalidYaml() {
+    RegoValue[] args = {new RegoString("name: [unterminated")};
+
+    assertEquals(RegoBoolean.FALSE, builtins.yamlIsValid(null, args));
+  }
+}


### PR DESCRIPTION
## Summary

- adds the `yaml.is_valid` builtin to `opa-builtins-json`
- validates YAML strings with the existing Jackson YAML mapper
- adds focused tests for registration, valid YAML, and invalid YAML

Closes open-policy-agent/java-opa-sdk#144.

## Verification

- `JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8 .\gradlew.bat --no-daemon --console=plain :opa-builtins:opa-builtins-json:test`
- `JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8 .\gradlew.bat --no-daemon --console=plain :opa-builtins:opa-builtins-json:check`

Note: On this Windows environment, the first Gradle run without explicit UTF-8 failed while compiling existing Unicode box-drawing characters in `MetricsPrinter.java` using Windows-1252. Rerunning with UTF-8 completed successfully.
