### PR TITLE
Fix missing/incorrect @OpaBuiltin annotations for union and object.union

### DIFF
--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/ObjectBuiltins.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/ObjectBuiltins.java
@@ -65,20 +65,34 @@ public class ObjectBuiltins {
   }
 
   @OpaBuiltin(
-      name = "object.keys",
-      description = "Returns a set of keys in the supplied object.",
+      name = "object.union",
+      description =
+          "Creates a new object of the asymmetric union of two objects. For example: "
+              + "`object.union({\"a\": 1}, {\"b\": 2})` results in `{\"a\": 1, \"b\": 2}`. "
+              + "If both objects have the same key and both values are objects, the values are "
+              + "merged recursively. Otherwise, the value in the right-hand object `b` wins.",
+      categories = {"objects"},
       args = {
         @OpaType(
             type = "object",
-            name = "object",
-            description = "object to get keys from",
+            name = "a",
+            description = "left-hand object",
+            dynamic = @OpaDynamic(keyType = "any", valueType = "any")),
+        @OpaType(
+            type = "object",
+            name = "b",
+            description = "right-hand object",
             dynamic = @OpaDynamic(keyType = "any", valueType = "any"))
       },
       result =
           @OpaType(
-              type = "set",
-              description = "set of keys in `object`",
-              dynamic = @OpaDynamic(type = "any")))
+              type = "object",
+              name = "output",
+              dynamic = @OpaDynamic(keyType = "any", valueType = "any"),
+              description =
+                  "a new object which is the result of an asymmetric recursive union of two "
+                      + "objects where conflicts are resolved by choosing the key from the "
+                      + "right-hand object `b`"))
   public RegoObject union(EvaluationContext ctx, RegoValue[] args) {
     if (!(args[0] instanceof RegoObject)) {
       throw new TypeError("object.union: operand 1 must be object but got " + args[0].getTypeName());

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/SetBuiltins.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/SetBuiltins.java
@@ -26,8 +26,25 @@ public class SetBuiltins {
         "union", instance::union);
   }
 
+  @OpaBuiltin(
+      name = "union",
+      description = "Returns the union of the given input sets.",
+      categories = {"sets"},
+      args = {
+        @OpaType(
+            type = "set",
+            name = "xs",
+            description = "set of sets to merge",
+            dynamic = @OpaDynamic(type = "set"))
+      },
+      result =
+          @OpaType(
+              type = "set",
+              name = "y",
+              description = "the union of all `xs` sets",
+              dynamic = @OpaDynamic(type = "any")))
   public RegoSet union(EvaluationContext ctx, RegoValue[] args) {
-    RegoSet xs = (RegoSet) args[0];
+    RegoSet xs = getArg(args, 0, RegoSet.class);
 
     Set<RegoValue> y =
         xs.getValue().stream()


### PR DESCRIPTION
## Summary
Both `union` and `object.union` are already fully implemented and functionally
correct  registered in their respective `builtins()` maps and dispatched
properly at runtime, so calling either from a Rego policy already works today.
The actual gap is in their `@OpaBuiltin` metadata annotations, which are used
to generate capabilities.json and docs. This PR fixes that metadata rather
than reimplementing the builtins, so the diff is smaller than the issue's
"missing builtins" framing might suggest.

## Issues
#137

## Changes
- Added the missing `@OpaBuiltin` annotation to `union` (SetBuiltins.java).
  It previously had none, so it was falling back to a minimal
  auto-generated capabilities entry with no description or arg types.
- Replaced `object.union`'s `@OpaBuiltin` annotation (ObjectBuiltins.java).
  It was copy-pasted from `object.keys` wrong name, wrong single-arg
  signature, wrong description. This also meant two methods in the same
  file both declared `name = "object.keys"`, an ambiguous collision since
  annotation-scanning order over declared methods isn't guaranteed by the
  JVM. Fixing the name resolves the collision as a side effect.
- Swapped a raw `(RegoSet) args[0]` cast for the existing `getArg` helper
  in `union`, so a bad input type throws a `TypeError` instead of a raw
  `ClassCastException` consistent with `intersection`/`and`/`or` in the
  same file.

## Testing
- `./gradlew :opa-evaluator:test` — full suite passes, including all
  compliance cases under `TestData/v1/union/` and `TestData/v1/objectunion/`.
- `./gradlew checkstyleMain checkstyleTest pmdMain pmdTest` — clean, no
  violations in either changed file.
- 11 pre-existing, unrelated failures were present both with and without
  this change (verified via `git stash`): 9 in `FileSystemBundleLoaderTest`
  (Windows-specific `InvalidPathException`, this repo's CI only runs
  `ubuntu-latest`) and 2 in `GoTimeLayoutConverterTest` (unrelated to
  bundle/builtin code).