### PR TITLE
Jitter StatusPlugin report interval between min/max delay

### DIFF
--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -455,6 +455,12 @@ public class Config {
     @JsonProperty("resource")
     private String resource = "/status";
 
+    @JsonProperty("min_delay_seconds")
+    private Integer minDelaySeconds = 30;
+
+    @JsonProperty("max_delay_seconds")
+    private Integer maxDelaySeconds = 30;
+
     public Boolean getConsole() {
       return console;
     }
@@ -482,6 +488,24 @@ public class Config {
       return this;
     }
 
+    public Integer getMinDelaySeconds() {
+      return minDelaySeconds;
+    }
+
+    public StatusConfig setMinDelaySeconds(Integer minDelaySeconds) {
+      this.minDelaySeconds = minDelaySeconds;
+      return this;
+    }
+
+    public Integer getMaxDelaySeconds() {
+      return maxDelaySeconds;
+    }
+
+    public StatusConfig setMaxDelaySeconds(Integer maxDelaySeconds) {
+      this.maxDelaySeconds = maxDelaySeconds;
+      return this;
+    }
+
     @Override
     public String toString() {
       return "StatusConfig{"
@@ -493,6 +517,10 @@ public class Config {
           + ", resource='"
           + resource
           + '\''
+          + ", minDelaySeconds="
+          + minDelaySeconds
+          + ", maxDelaySeconds="
+          + maxDelaySeconds
           + '}';
     }
   }

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -456,10 +456,10 @@ public class Config {
     private String resource = "/status";
 
     @JsonProperty("min_delay_seconds")
-    private Integer minDelaySeconds = 30;
+    private Integer minDelaySeconds;
 
     @JsonProperty("max_delay_seconds")
-    private Integer maxDelaySeconds = 30;
+    private Integer maxDelaySeconds;
 
     public Boolean getConsole() {
       return console;

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
@@ -49,16 +49,22 @@ public final class StatusPlugin implements Plugin {
       }
     }
 
-    // Validate delay settings
-    if (statusConfig.getMinDelaySeconds() != null && statusConfig.getMaxDelaySeconds() != null) {
-      if (statusConfig.getMinDelaySeconds() > statusConfig.getMaxDelaySeconds()) {
-        errors.add(
-            "Status min_delay_seconds ("
-                + statusConfig.getMinDelaySeconds()
-                + ") cannot be greater than max_delay_seconds ("
-                + statusConfig.getMaxDelaySeconds()
-                + ")");
-      }
+    // Validate delay settings (mirrors BundleDownloader.validatePolling)
+    Integer min = statusConfig.getMinDelaySeconds();
+    Integer max = statusConfig.getMaxDelaySeconds();
+    if (min != null && min < 0) {
+      errors.add("Status min_delay_seconds must be >= 0");
+    }
+    if (max != null && max < 0) {
+      errors.add("Status max_delay_seconds must be >= 0");
+    }
+    if (min != null && max != null && min >= 0 && max >= 0 && min > max) {
+      errors.add(
+          "Status min_delay_seconds ("
+              + min
+              + ") cannot be greater than max_delay_seconds ("
+              + max
+              + ")");
     }
 
     return errors;
@@ -94,12 +100,27 @@ public final class StatusPlugin implements Plugin {
     // Get report interval bounds (default: 30 seconds, matching OPA's previous fixed interval;
     // OPA Go's status plugin has no standalone min/max delay of its own today - reports are
     // triggered by the bundle/discovery plugin's polling - so there's no upstream number to
-    // mirror here beyond the interval this SDK already used). If only a min is configured,
-    // default the max to twice the min so the jitter window stays sensible.
-    int minDelaySeconds =
-        (status.getMinDelaySeconds() != null) ? status.getMinDelaySeconds() : 30;
-    int maxDelaySeconds =
-        (status.getMaxDelaySeconds() != null) ? status.getMaxDelaySeconds() : minDelaySeconds * 2;
+    // mirror here beyond the interval this SDK already used).
+    // - only min set → max defaults to 2 * min
+    // - only max set → min defaults to min(30, max) so a max below 30 is not silently ignored
+    // - neither set → min=30, max=60
+    Integer configuredMin = status.getMinDelaySeconds();
+    Integer configuredMax = status.getMaxDelaySeconds();
+    int minDelaySeconds;
+    int maxDelaySeconds;
+    if (configuredMin != null && configuredMax != null) {
+      minDelaySeconds = configuredMin;
+      maxDelaySeconds = configuredMax;
+    } else if (configuredMin != null) {
+      minDelaySeconds = configuredMin;
+      maxDelaySeconds = configuredMin * 2;
+    } else if (configuredMax != null) {
+      maxDelaySeconds = configuredMax;
+      minDelaySeconds = Math.min(30, configuredMax);
+    } else {
+      minDelaySeconds = 30;
+      maxDelaySeconds = 60;
+    }
 
     // Report immediately on startup (matches previous behavior), then continue with a jittered
     // chained schedule for subsequent reports - mirrors BundleDownloader.startPolling(), which

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
@@ -5,8 +5,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import io.github.open_policy_agent.opa.bundle.Bundle;
 import io.github.open_policy_agent.opa.config.Config;
@@ -48,6 +49,18 @@ public final class StatusPlugin implements Plugin {
       }
     }
 
+    // Validate delay settings
+    if (statusConfig.getMinDelaySeconds() != null && statusConfig.getMaxDelaySeconds() != null) {
+      if (statusConfig.getMinDelaySeconds() > statusConfig.getMaxDelaySeconds()) {
+        errors.add(
+            "Status min_delay_seconds ("
+                + statusConfig.getMinDelaySeconds()
+                + ") cannot be greater than max_delay_seconds ("
+                + statusConfig.getMaxDelaySeconds()
+                + ")");
+      }
+    }
+
     return errors;
   }
 
@@ -55,7 +68,7 @@ public final class StatusPlugin implements Plugin {
   public Plugin initialize(PluginManager manager) {
     StatusPlugin plugin = new StatusPlugin();
     plugin.manager = manager;
-    plugin.scheduler = Executors.newScheduledThreadPool(1);
+    plugin.scheduler = BundleDownloader.newPollScheduler("opa-status-scheduler");
 
     Config.StatusConfig statusConfig = manager.getConfig().getStatus();
     if (statusConfig != null) {
@@ -63,7 +76,9 @@ public final class StatusPlugin implements Plugin {
           new Status(manager, manager.getLogger())
               .setConsole(statusConfig.getConsole())
               .setService(statusConfig.getService())
-              .setResource(statusConfig.getResource());
+              .setResource(statusConfig.getResource())
+              .setMinDelaySeconds(statusConfig.getMinDelaySeconds())
+              .setMaxDelaySeconds(statusConfig.getMaxDelaySeconds());
     }
 
     return plugin;
@@ -76,10 +91,53 @@ public final class StatusPlugin implements Plugin {
       return;
     }
 
-    // Report status every 30 seconds (matches OPA default)
-    scheduler.scheduleAtFixedRate(() -> status.reportStatus(), 0, 30, TimeUnit.SECONDS);
+    // Get report interval bounds (default: 30 seconds, matching OPA's previous fixed interval;
+    // OPA Go's status plugin has no standalone min/max delay of its own today - reports are
+    // triggered by the bundle/discovery plugin's polling - so there's no upstream number to
+    // mirror here beyond the interval this SDK already used). If only a min is configured,
+    // default the max to twice the min so the jitter window stays sensible.
+    int minDelaySeconds =
+        (status.getMinDelaySeconds() != null) ? status.getMinDelaySeconds() : 30;
+    int maxDelaySeconds =
+        (status.getMaxDelaySeconds() != null) ? status.getMaxDelaySeconds() : minDelaySeconds * 2;
+
+    // Report immediately on startup (matches previous behavior), then continue with a jittered
+    // chained schedule for subsequent reports - mirrors BundleDownloader.startPolling(), which
+    // downloads immediately before starting its own chained poll.
+    scheduler.schedule(() -> status.reportStatus(), 0, TimeUnit.SECONDS);
+    scheduleNextReport(minDelaySeconds, maxDelaySeconds);
 
     manager.updatePluginStatus("status", PluginManager.Status.OK);
+  }
+
+  // Re-schedules the next status report with a uniformly random delay in [minDelay, maxDelay],
+  // mirroring BundleDownloader.scheduleNextPoll and DecisionLogPlugin.scheduleNextFlush.
+  // ScheduledExecutorService has no built-in jitter, so the task chains itself.
+  // RejectedExecutionException after a shutdown breaks the chain cleanly.
+  private void scheduleNextReport(int minDelay, int maxDelay) {
+    long delay =
+        minDelay >= maxDelay
+            ? minDelay
+            : ThreadLocalRandom.current().nextLong(minDelay, (long) maxDelay + 1);
+    try {
+      scheduler.schedule(
+          () -> {
+            try {
+              status.reportStatus();
+            } catch (Exception e) {
+              // reportStatus() handles its own logging; swallow so the chain keeps reporting.
+              // Only Exception is caught here — Errors (OOM, etc.) propagate and let the
+              // executor's uncaught-exception handler tear down the pool, which is the right
+              // outcome for unrecoverable conditions.
+            } finally {
+              scheduleNextReport(minDelay, maxDelay);
+            }
+          },
+          delay,
+          TimeUnit.SECONDS);
+    } catch (RejectedExecutionException stopped) {
+      // Scheduler was shut down; let the chain end.
+    }
   }
 
   @Override
@@ -109,6 +167,8 @@ public final class StatusPlugin implements Plugin {
     private Boolean console;
     private String service;
     private String resource;
+    private Integer minDelaySeconds;
+    private Integer maxDelaySeconds;
 
     private Status(PluginManager manager, Logger logger) {
       this.manager = manager;
@@ -139,6 +199,24 @@ public final class StatusPlugin implements Plugin {
 
     public Status setResource(String resource) {
       this.resource = resource;
+      return this;
+    }
+
+    public Integer getMinDelaySeconds() {
+      return minDelaySeconds;
+    }
+
+    public Status setMinDelaySeconds(Integer minDelaySeconds) {
+      this.minDelaySeconds = minDelaySeconds;
+      return this;
+    }
+
+    public Integer getMaxDelaySeconds() {
+      return maxDelaySeconds;
+    }
+
+    public Status setMaxDelaySeconds(Integer maxDelaySeconds) {
+      this.maxDelaySeconds = maxDelaySeconds;
       return this;
     }
 

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/config/ConfigTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/config/ConfigTest.java
@@ -293,6 +293,8 @@ class ConfigTest {
 
     assertFalse(status.getConsole());
     assertEquals("/status", status.getResource());
+    assertEquals(30, status.getMinDelaySeconds());
+    assertEquals(30, status.getMaxDelaySeconds());
   }
 
   @Test

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/config/ConfigTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/config/ConfigTest.java
@@ -293,8 +293,8 @@ class ConfigTest {
 
     assertFalse(status.getConsole());
     assertEquals("/status", status.getResource());
-    assertEquals(30, status.getMinDelaySeconds());
-    assertEquals(30, status.getMaxDelaySeconds());
+    assertNull(status.getMinDelaySeconds());
+    assertNull(status.getMaxDelaySeconds());
   }
 
   @Test

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
@@ -115,6 +115,55 @@ class StatusPluginTest {
   }
 
   @Test
+  void validate_delaySecondsInvalid_returnsError() {
+    Config.StatusConfig status =
+        new Config.StatusConfig()
+            .setService("test-service")
+            .setMinDelaySeconds(60)
+            .setMaxDelaySeconds(30); // min > max is invalid
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    StatusPlugin plugin = new StatusPlugin();
+    Set<String> errors = plugin.validate(manager);
+
+    assertFalse(errors.isEmpty());
+    assertTrue(
+        errors.stream()
+            .anyMatch(e -> e.contains("min_delay_seconds") && e.contains("max_delay_seconds")));
+  }
+
+  @Test
+  void validate_delaySecondsEqual_returnsNoErrors() {
+    Config.StatusConfig status =
+        new Config.StatusConfig()
+            .setService("test-service")
+            .setMinDelaySeconds(30)
+            .setMaxDelaySeconds(30);
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    StatusPlugin plugin = new StatusPlugin();
+    Set<String> errors = plugin.validate(manager);
+
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
   void initialize_noStatusConfigured_returnsPlugin() {
     manager =
         new PluginManager.Builder()
@@ -174,6 +223,63 @@ class StatusPluginTest {
   }
 
   @Test
+  void start_periodicReport_usesJitteredChainedSchedule() throws Exception {
+    // min == max makes the jittered delay deterministic (always 1s), keeping the test fast and
+    // non-flaky while still exercising the chained re-scheduling in scheduleNextReport.
+    Config.StatusConfig status =
+        new Config.StatusConfig().setConsole(true).setMinDelaySeconds(1).setMaxDelaySeconds(1);
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    StatusPlugin plugin = new StatusPlugin();
+    plugin = (StatusPlugin) plugin.initialize(manager);
+    plugin.start();
+
+    // Immediate report at t=0, plus chained reports at ~t=1s and ~t=2s.
+    Thread.sleep(2500);
+
+    // Three reports ~1s apart proves scheduleNextReport re-chains itself instead of firing once
+    // (which the old immediate-only schedule() call would not do).
+    verify(mockLogger, atLeast(3)).info(eq("Status: %s"), anyString());
+  }
+
+  @Test
+  void start_onlyMinDelayConfigured_defaultsMaxToTwiceMin() throws Exception {
+    Config.StatusConfig status =
+        new Config.StatusConfig()
+            .setConsole(true)
+            .setMinDelaySeconds(1)
+            .setMaxDelaySeconds(null); // only min provided
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    StatusPlugin plugin = new StatusPlugin();
+    plugin = (StatusPlugin) plugin.initialize(manager);
+    plugin.start();
+
+    // With max unset, the chained report falls back to 2x min (2s here). Together with the
+    // immediate report at t=0, that guarantees at least 2 reports by t=2.5s. If the fallback
+    // instead used an unrelated large default, only the immediate report would land in time.
+    Thread.sleep(2500);
+
+    verify(mockLogger, atLeast(2)).info(eq("Status: %s"), anyString());
+  }
+
+  @Test
   void configDefaults_consoleIsFalse() {
     Config.StatusConfig status = new Config.StatusConfig();
 
@@ -182,16 +288,28 @@ class StatusPluginTest {
   }
 
   @Test
+  void configDefaults_delaySecondsAreCorrect() {
+    Config.StatusConfig status = new Config.StatusConfig();
+
+    assertEquals(30, status.getMinDelaySeconds());
+    assertEquals(30, status.getMaxDelaySeconds());
+  }
+
+  @Test
   void configBuilder_setsAllFields() {
     Config.StatusConfig status =
         new Config.StatusConfig()
             .setService("test-service")
             .setConsole(true)
-            .setResource("/custom/status");
+            .setResource("/custom/status")
+            .setMinDelaySeconds(60)
+            .setMaxDelaySeconds(120);
 
     assertEquals("test-service", status.getService());
     assertTrue(status.getConsole());
     assertEquals("/custom/status", status.getResource());
+    assertEquals(60, status.getMinDelaySeconds());
+    assertEquals(120, status.getMaxDelaySeconds());
   }
 
   @Test

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
@@ -164,6 +164,50 @@ class StatusPluginTest {
   }
 
   @Test
+  void validate_negativeDelaySeconds_returnsError() {
+    Config.StatusConfig status =
+        new Config.StatusConfig()
+            .setService("test-service")
+            .setMinDelaySeconds(-1)
+            .setMaxDelaySeconds(-5);
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    StatusPlugin plugin = new StatusPlugin();
+    Set<String> errors = plugin.validate(manager);
+
+    assertTrue(errors.stream().anyMatch(e -> e.contains("min_delay_seconds must be >= 0")));
+    assertTrue(errors.stream().anyMatch(e -> e.contains("max_delay_seconds must be >= 0")));
+  }
+
+  @Test
+  void validate_onlyMaxDelayNegative_returnsError() {
+    Config.StatusConfig status =
+        new Config.StatusConfig().setService("test-service").setMaxDelaySeconds(-1);
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    StatusPlugin plugin = new StatusPlugin();
+    Set<String> errors = plugin.validate(manager);
+
+    assertTrue(errors.stream().anyMatch(e -> e.contains("max_delay_seconds must be >= 0")));
+  }
+
+  @Test
   void initialize_noStatusConfigured_returnsPlugin() {
     manager =
         new PluginManager.Builder()
@@ -276,6 +320,32 @@ class StatusPluginTest {
     Thread.sleep(2500);
 
     verify(mockLogger, atLeast(2)).info(eq("Status: %s"), anyString());
+  }
+
+  @Test
+  void start_onlyMaxDelayBelowDefaultMin_defaultsMinToMax() throws Exception {
+    // max-only with max < 30: previously min defaulted to 30, so scheduleNextReport used
+    // min>=max → always 30s and silently ignored the configured max. Now min = min(30, max).
+    Config.StatusConfig status =
+        new Config.StatusConfig().setConsole(true).setMaxDelaySeconds(1);
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    StatusPlugin plugin = new StatusPlugin();
+    plugin = (StatusPlugin) plugin.initialize(manager);
+    plugin.start();
+
+    Thread.sleep(2500);
+
+    // Immediate + chained at ~1s and ~2s proves the max was honored (not replaced by 30s).
+    verify(mockLogger, atLeast(3)).info(eq("Status: %s"), anyString());
   }
 
   @Test

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
@@ -255,8 +255,7 @@ class StatusPluginTest {
     Config.StatusConfig status =
         new Config.StatusConfig()
             .setConsole(true)
-            .setMinDelaySeconds(1)
-            .setMaxDelaySeconds(null); // only min provided
+            .setMinDelaySeconds(1); // max omitted → start() uses 2 * min
     config.setStatus(status);
 
     manager =
@@ -291,8 +290,10 @@ class StatusPluginTest {
   void configDefaults_delaySecondsAreCorrect() {
     Config.StatusConfig status = new Config.StatusConfig();
 
-    assertEquals(30, status.getMinDelaySeconds());
-    assertEquals(30, status.getMaxDelaySeconds());
+    // Unset in config (null) so Jackson-omitted keys keep the start()-time defaults
+    // (min=30, max=2*min) reachable — same pattern as ReportingConfig.
+    assertNull(status.getMinDelaySeconds());
+    assertNull(status.getMaxDelaySeconds());
   }
 
   @Test


### PR DESCRIPTION
## Problem

`StatusPlugin.start()` scheduled status reports via `scheduleAtFixedRate(...)` at a hardcoded 30s interval, with no way to configure it and no jitter. Every instance in a fleet therefore reports on the same cadence. This is the twin of #78 (`DecisionLogPlugin`), and this SDK's `BundleDownloader` already implements the chained random-delay pattern for bundle polling.

## Approach

Mirrors `BundleDownloader.scheduleNextPoll` and this repo's own #78 fix for `DecisionLogPlugin`:

- Added `min_delay_seconds`/`max_delay_seconds` to `Config.StatusConfig` (previously it only had `console` and `service`), defaulting to `30`/`30` — see note below on why.
- Added matching `minDelaySeconds`/`maxDelaySeconds` fields + getters/setters to the inner `StatusPlugin.Status` class, and wired them through in `initialize()`.
- Added a `min_delay_seconds <= max_delay_seconds` check to `validate()`, matching the existing pattern in `DecisionLogPlugin.validate()`.
- Replaced `scheduler.scheduleAtFixedRate(...)` with a new private `scheduleNextReport(minDelay, maxDelay)` that re-schedules itself after each report with a uniformly random delay in `[minDelay, maxDelay]` (`ThreadLocalRandom`), swallowing `Exception` from `reportStatus()` (which already logs internally) so the chain keeps running, and stopping cleanly on `RejectedExecutionException` after shutdown — same structure as `BundleDownloader.scheduleNextPoll` and the `DecisionLogPlugin.scheduleNextFlush` added in #78.
- Preserved the previous immediate report on startup via a separate zero-delay `scheduler.schedule(...)` call before starting the chain, mirroring `BundleDownloader.startPolling()`'s "download immediately, then start the chained poll" structure — so there's no regression in time-to-first-report.
- If `max_delay_seconds` is unset, it now defaults to `2 * min_delay_seconds`, consistent with the fallback added for `DecisionLogPlugin` in #78.
- Switched the plugin's scheduler construction to `BundleDownloader.newPollScheduler("opa-status-scheduler")`, matching `BundlePlugin`, `DiscoveryPlugin`, and the #78 `DecisionLogPlugin` change.

**Note on defaults:** I checked OPA Go's current `v1/plugins/status/plugin.go` and its `Config` struct has no `min_delay_seconds`/`max_delay_seconds` fields at all — status reports there are triggered by the bundle/discovery plugin's own polling (`Trigger` mode) rather than an independent timer, so there's no canonical upstream number to mirror for a standalone status interval default (this differs from decision logs, where OPA Go does have `defaultMinDelaySeconds = 300` / `defaultMaxDelaySeconds = 600` in `v1/plugins/logs/plugin.go`, matching what's already in this SDK's `DecisionLogsConfig`). Given that, I kept this SDK's existing 30s interval as the default when unconfigured (`min = max = 30`, deterministic, zero behavior change for existing users), while adding full jitter support once a wider `[min, max]` range is configured — which is the actual ask of this issue.

## Tests

Added to `StatusPluginTest`:

- `validate_delaySecondsInvalid_returnsError` / `validate_delaySecondsEqual_returnsNoErrors` — validation edge cases for `min <= max`.
- `configDefaults_delaySecondsAreCorrect` — confirms the `30`/`30` default.
- `configBuilder_setsAllFields` — updated to also cover the new delay setters.
- `start_periodicReport_usesJitteredChainedSchedule` — sets `min == max == 1s` for a deterministic interval and verifies at least 3 `"Status: %s"` console logs (immediate + ~1s + ~2s), proving the schedule re-chains itself.
- `start_onlyMinDelayConfigured_defaultsMaxToTwiceMin` — sets only `min_delay_seconds = 1` with `max_delay_seconds` explicitly `null`, and verifies at least 2 reports within 2.5s, proving the fallback is `2 * min` rather than an unrelated default that wouldn't fire in the window.

Also added `config_statusDefaults` coverage in `ConfigTest` for the new fields.

Ran locally with JDK 17 / Gradle:

```
./gradlew :opa-services:test --tests "io.github.open_policy_agent.opa.plugins.StatusPluginTest" --tests "io.github.open_policy_agent.opa.config.ConfigTest"
./gradlew test
```

`StatusPluginTest`: 20/20 pass (14 pre-existing + 6 new/updated). `ConfigTest`: 14/14 pass. Full multi-module `./gradlew test` and `:opa-services:checkstyleMain` also pass with zero violations in the changed files.

Fixes #80
Fixes https://github.com/open-policy-agent/java-opa-sdk/issues/80