### PR TITLE
chore: group Dependabot updates into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,27 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      gradle-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "gomod"
     directory: "/tools/generate-compliance-tests"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      gomod-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group dependabot PRs together
