### PR TITLE
feat(status): add configurable resource path for status uploads

### DIFF
--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -452,6 +452,9 @@ public class Config {
     private Boolean console = false;
     private String service;
 
+    @JsonProperty("resource")
+    private String resource = "/status";
+
     public Boolean getConsole() {
       return console;
     }
@@ -470,9 +473,27 @@ public class Config {
       return this;
     }
 
+    public String getResource() {
+      return resource;
+    }
+
+    public StatusConfig setResource(String resource) {
+      this.resource = resource;
+      return this;
+    }
+
     @Override
     public String toString() {
-      return "StatusConfig{" + "console=" + console + ", service='" + service + '\'' + '}';
+      return "StatusConfig{"
+          + "console="
+          + console
+          + ", service='"
+          + service
+          + '\''
+          + ", resource='"
+          + resource
+          + '\''
+          + '}';
     }
   }
 

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
@@ -62,7 +62,8 @@ public final class StatusPlugin implements Plugin {
       plugin.status =
           new Status(manager, manager.getLogger())
               .setConsole(statusConfig.getConsole())
-              .setService(statusConfig.getService());
+              .setService(statusConfig.getService())
+              .setResource(statusConfig.getResource());
     }
 
     return plugin;
@@ -107,6 +108,7 @@ public final class StatusPlugin implements Plugin {
     private final Logger logger;
     private Boolean console;
     private String service;
+    private String resource;
 
     private Status(PluginManager manager, Logger logger) {
       this.manager = manager;
@@ -128,6 +130,15 @@ public final class StatusPlugin implements Plugin {
 
     public Status setService(String service) {
       this.service = service;
+      return this;
+    }
+
+    public String getResource() {
+      return resource;
+    }
+
+    public Status setResource(String resource) {
+      this.resource = resource;
       return this;
     }
 
@@ -225,9 +236,10 @@ public final class StatusPlugin implements Plugin {
       }
 
       try {
-        // Send status report to service
-        // Default resource path is /status (same as OPA)
-        svc.post("/status", statusReport.toString());
+        // Determine resource path (default: /status)
+        String path = (resource != null && !resource.isEmpty()) ? resource : "/status";
+
+        svc.post(path, statusReport.toString());
         logger.debug("Status report sent to service '%s'", service);
       } catch (Exception e) {
         logger.error("Failed to send status to service '%s': %s", service, e.getMessage());

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/config/ConfigTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/config/ConfigTest.java
@@ -292,6 +292,7 @@ class ConfigTest {
     Config.StatusConfig status = new Config.StatusConfig();
 
     assertFalse(status.getConsole());
+    assertEquals("/status", status.getResource());
   }
 
   @Test

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
@@ -178,15 +178,63 @@ class StatusPluginTest {
     Config.StatusConfig status = new Config.StatusConfig();
 
     assertFalse(status.getConsole());
+    assertEquals("/status", status.getResource());
   }
 
   @Test
   void configBuilder_setsAllFields() {
     Config.StatusConfig status =
-        new Config.StatusConfig().setService("test-service").setConsole(true);
+        new Config.StatusConfig()
+            .setService("test-service")
+            .setConsole(true)
+            .setResource("/custom/status");
 
     assertEquals("test-service", status.getService());
     assertTrue(status.getConsole());
+    assertEquals("/custom/status", status.getResource());
+  }
+
+  @Test
+  void initialize_wiresDefaultResourcePath() throws Exception {
+    Config.StatusConfig status =
+        new Config.StatusConfig().setService("test-service").setConsole(false);
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    StatusPlugin plugin = (StatusPlugin) new StatusPlugin().initialize(manager);
+    StatusPlugin.Status statusReporter = getStatusReporter(plugin);
+
+    assertEquals("/status", statusReporter.getResource());
+  }
+
+  @Test
+  void initialize_wiresCustomResourcePath() throws Exception {
+    Config.StatusConfig status =
+        new Config.StatusConfig()
+            .setService("test-service")
+            .setConsole(false)
+            .setResource("/custom/status");
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    StatusPlugin plugin = (StatusPlugin) new StatusPlugin().initialize(manager);
+    StatusPlugin.Status statusReporter = getStatusReporter(plugin);
+
+    assertEquals("/custom/status", statusReporter.getResource());
   }
 
   @Test
@@ -382,10 +430,16 @@ class StatusPluginTest {
   }
 
   private ObjectNode buildStatusReport(StatusPlugin plugin) throws Exception {
+    return buildStatusReport(getStatusReporter(plugin));
+  }
+
+  private static StatusPlugin.Status getStatusReporter(StatusPlugin plugin) throws Exception {
     java.lang.reflect.Field statusField = StatusPlugin.class.getDeclaredField("status");
     statusField.setAccessible(true);
-    StatusPlugin.Status statusReporter = (StatusPlugin.Status) statusField.get(plugin);
+    return (StatusPlugin.Status) statusField.get(plugin);
+  }
 
+  private ObjectNode buildStatusReport(StatusPlugin.Status statusReporter) throws Exception {
     java.lang.reflect.Method buildStatusMethod =
         StatusPlugin.Status.class.getDeclaredMethod("buildStatusReport");
     buildStatusMethod.setAccessible(true);


### PR DESCRIPTION
## Summary

- Add `resource` to `Config.StatusConfig` and `StatusPlugin.Status`, mirroring `DecisionLogs.setResource`
- Default resource path remains `/status` when unset, preserving current behavior
- Wire configured resource through plugin initialization and use it in `sendToService`

Fixes #81

## Test plan

- [x] `./gradlew :opa-services:test --tests "io.github.open_policy_agent.opa.plugins.StatusPluginTest" --tests "io.github.open_policy_agent.opa.config.ConfigTest.config_statusDefaults"` (Java 17) — BUILD SUCCESSFUL
- [x] Default `/status` resource asserted in config and initialization tests
- [x] Custom `/custom/status` resource asserted in builder and initialization tests


Made with [Cursor](https://cursor.com)