### PR TITLE
feat(services): support dynamic entrypoint evaluation via DecisionOptions

### DIFF
--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/Opa.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/Opa.java
@@ -243,17 +243,26 @@ public class Opa {
     boolean useMetrics = showMetrics || (options != null && options.showMetrics);
     Metrics metrics = useMetrics ? new SimpleMetrics() : NoOpMetrics.Instance();
 
+    String entrypoint = resolveEntrypoint(options);
+
     EvaluationContext.Builder builder =
         new EvaluationContext.Builder()
             .withStore(store)
             .withMetrics(metrics)
-            .withEntrypoint(defaultEntrypoint);
+            .withEntrypoint(entrypoint);
 
     if (options != null && options.getProfiler() != null) {
       builder.withProfiler(options.getProfiler());
     }
 
     return builder.build();
+  }
+
+  private String resolveEntrypoint(DecisionOptions options) {
+    if (options != null && options.getEntrypoint() != null && !options.getEntrypoint().isEmpty()) {
+        return options.getEntrypoint();
+    }
+    return defaultEntrypoint;
   }
 
   private static String resolveDecisionId(DecisionOptions options) {
@@ -386,6 +395,7 @@ public class Opa {
     private Profiler profiler;
     private boolean instrument;
     String decisionID;
+    private String entrypoint;
 
     public long getNowNs() {
       return nowNs;
@@ -465,6 +475,15 @@ public class Opa {
 
     public DecisionOptions setDecisionID(String decisionID) {
       this.decisionID = decisionID;
+      return this;
+    }
+
+    public String getEntrypoint() {
+      return entrypoint;
+    }
+
+    public DecisionOptions setEntrypoint(String entrypoint) {
+      this.entrypoint = entrypoint;
       return this;
     }
   }

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/Opa.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/Opa.java
@@ -260,9 +260,14 @@ public class Opa {
 
   private String resolveEntrypoint(DecisionOptions options) {
     if (options != null && options.getEntrypoint() != null && !options.getEntrypoint().isEmpty()) {
-        return options.getEntrypoint();
+      return options.getEntrypoint();
     }
-    return defaultEntrypoint;
+
+    if (defaultEntrypoint != null) {
+      return defaultEntrypoint;
+    }
+
+    return "";
   }
 
   private static String resolveDecisionId(DecisionOptions options) {
@@ -283,13 +288,10 @@ public class Opa {
       return;
     }
 
-    String path =
-        (options.getPath() != null && !options.getPath().isEmpty())
-            ? options.getPath()
-            : (defaultEntrypoint != null && !defaultEntrypoint.isEmpty()) ? defaultEntrypoint : "";
+    String entrypoint = resolveEntrypoint(options);
 
     plugin.logDecision(
-        decisionId, input, result, path,
+        decisionId, input, result, entrypoint,
         ctx.getEvalStartTime(), ctx.metrics, ctx.getNdCacheValues());
   }
 
@@ -387,7 +389,6 @@ public class Opa {
 
   public static class DecisionOptions {
     private long nowNs;
-    private String path;
     private JsonNode input;
     private Object ndbCache;
     private boolean strictBuiltinErrors;
@@ -403,15 +404,6 @@ public class Opa {
 
     public DecisionOptions setNowNs(long nowNs) {
       this.nowNs = nowNs;
-      return this;
-    }
-
-    public String getPath() {
-      return path;
-    }
-
-    public DecisionOptions setPath(String path) {
-      this.path = path;
       return this;
     }
 

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/OpaTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/OpaTest.java
@@ -194,7 +194,6 @@ class OpaTest {
     Opa.DecisionOptions options =
         new Opa.DecisionOptions()
             .setNowNs(System.nanoTime())
-            .setPath("example/allow")
             .setInput(input)
             .setStrictBuiltinErrors(true)
             .showMetrics()
@@ -204,7 +203,6 @@ class OpaTest {
             .setEntrypoint(entrypoint);
 
     assertNotNull(options.getInput());
-    assertNotNull(options.getPath());
     assertTrue(options.getShowMetrics());
     assertNotNull(options.getProfiler());
     assertNotNull(options.getDecisionID());

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/OpaTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/OpaTest.java
@@ -189,6 +189,7 @@ class OpaTest {
   @Test
   void decisionOptions_builder_setsAllFields() {
     JsonNode input = objectMapper.createObjectNode().put("user", "bob");
+    String entrypoint = "test/allow";
 
     Opa.DecisionOptions options =
         new Opa.DecisionOptions()
@@ -199,7 +200,8 @@ class OpaTest {
             .showMetrics()
             .setProfiler(new DurationProfiler())
             .setInstrument(true)
-            .setDecisionID("test-decision-id");
+            .setDecisionID("test-decision-id")
+            .setEntrypoint(entrypoint);
 
     assertNotNull(options.getInput());
     assertNotNull(options.getPath());
@@ -208,6 +210,7 @@ class OpaTest {
     assertNotNull(options.getDecisionID());
     assertTrue(options.isStrictBuiltinErrors());
     assertTrue(options.isInstrument());
+    assertEquals(entrypoint, options.getEntrypoint());
   }
 
   @Test
@@ -217,6 +220,7 @@ class OpaTest {
     assertEquals(0, options.getNowNs());
     assertFalse(options.isStrictBuiltinErrors());
     assertFalse(options.isInstrument());
+    assertNull(options.getEntrypoint());
   }
 
   @Test


### PR DESCRIPTION
### Description
This PR introduces the ability to dynamically override the policy entrypoint on a per-request basis using `DecisionOptions`. 

### Motivation
When working with compiled bundles containing multiple entrypoints (e.g., built using `opa build -t plan -e example/allow -e example/foo -e example/bar -b . -o bundle.tar.gz`), the current `Opa.java` forces all evaluations through the `defaultEntrypoint`.

By adding an `entrypoint` field to `DecisionOptions`, it will now be possible to evaluate different branches of a plan bundle on the fly using a single `Opa` instance.

### Changes
1. **`Opa.DecisionOptions`**: Added a private `entrypoint` field along with its respective getter and setter.
2. **`Opa.buildContext(DecisionOptions options)`**: Updated the evaluation context building block to look up `options.getEntrypoint()`. If provided, it overrides the standard `defaultEntrypoint`.