### PR TITLE
feat(evaluator): implement internal.member_2 and internal.member_3 builtins

### DIFF
--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/AggregateBuiltins.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/AggregateBuiltins.java
@@ -16,6 +16,7 @@ import io.github.open_policy_agent.opa.ast.types.RegoInt32;
 import io.github.open_policy_agent.opa.ast.types.RegoNull;
 import io.github.open_policy_agent.opa.ast.types.RegoNumber;
 import io.github.open_policy_agent.opa.ast.types.RegoObject;
+import io.github.open_policy_agent.opa.ast.types.RegoSet;
 import io.github.open_policy_agent.opa.ast.types.RegoString;
 import io.github.open_policy_agent.opa.ast.types.RegoValue;
 import io.github.open_policy_agent.opa.rego.EvaluationContext;
@@ -32,7 +33,8 @@ public class AggregateBuiltins {
                 "sum", instance::sum,
                 "count", instance::count,
                 "product", instance::product,
-                "internal.member_2", instance::member);
+                "internal.member_2", instance::member2,
+                "internal.member_3", instance::member3);
     }
 
     @OpaBuiltin(
@@ -180,7 +182,16 @@ public class AggregateBuiltins {
         }
     }
 
-    public RegoBoolean member(EvaluationContext ctx, RegoValue[] args) {
+    @OpaBuiltin(
+            name = "internal.member_2",
+            description = "Checks membership of an item in a collection or object",
+            categories = {"aggregates"},
+            args = {
+                    @OpaType(type = "any", name = "x", description = "item to check for membership"),
+                    @OpaType(type = "any", name = "collection", description = "collection or object to check in")
+            },
+            result = @OpaType(type = "boolean", description = "true if x is in collection; false otherwise"))
+    public RegoBoolean member2(EvaluationContext ctx, RegoValue[] args) {
         RegoValue x = args[0];
         RegoValue y = args[1];
 
@@ -196,6 +207,52 @@ public class AggregateBuiltins {
             }
         }
         // For non-collections (string, number, etc.), return false
+        return RegoBoolean.FALSE;
+    }
+
+    @OpaBuiltin(
+            name = "internal.member_3",
+            description = "Checks key/index and item membership in a collection or object",
+            categories = {"aggregates"},
+            args = {
+                    @OpaType(type = "any", name = "key", description = "key or index"),
+                    @OpaType(type = "any", name = "value", description = "item or value"),
+                    @OpaType(type = "any", name = "collection", description = "collection or object to check in")
+            },
+            result = @OpaType(type = "boolean", description = "true if key and value match in collection; false otherwise"))
+    public RegoBoolean member3(EvaluationContext ctx, RegoValue[] args) {
+        RegoValue key = args[0];
+        RegoValue value = args[1];
+        RegoValue collection = args[2];
+
+        if (collection instanceof RegoObject) {
+            RegoObject obj = (RegoObject) collection;
+            if (obj.hasProperty(key) && obj.getProperty(key).equals(value)) {
+                return RegoBoolean.TRUE;
+            }
+        } else if (collection instanceof RegoArray) {
+            RegoArray array = (RegoArray) collection;
+            if (key instanceof RegoInt32) {
+                int idx = ((RegoInt32) key).getValue();
+                if (idx >= 0 && idx < array.length() && array.getValues().get(idx).equals(value)) {
+                    return RegoBoolean.TRUE;
+                }
+            } else if (key instanceof RegoNumber && !((RegoNumber) key).isDecimal()) {
+                BigInteger bigInt = ((RegoNumber) key).getBigIntValue();
+                if (bigInt != null && bigInt.compareTo(BigInteger.ZERO) >= 0
+                        && bigInt.compareTo(BigInteger.valueOf(array.length())) < 0) {
+                    int idx = bigInt.intValue();
+                    if (array.getValues().get(idx).equals(value)) {
+                        return RegoBoolean.TRUE;
+                    }
+                }
+            }
+        } else if (collection instanceof RegoSet) {
+            RegoSet set = (RegoSet) collection;
+            if (key.equals(value) && set.contains(value)) {
+                return RegoBoolean.TRUE;
+            }
+        }
         return RegoBoolean.FALSE;
     }
 }

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/AggregateBuiltinsTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/AggregateBuiltinsTest.java
@@ -1,0 +1,87 @@
+package io.github.open_policy_agent.opa.ast.builtin.impls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.open_policy_agent.opa.ast.types.RegoArray;
+import io.github.open_policy_agent.opa.ast.types.RegoBoolean;
+import io.github.open_policy_agent.opa.ast.types.RegoInt32;
+import io.github.open_policy_agent.opa.ast.types.RegoObject;
+import io.github.open_policy_agent.opa.ast.types.RegoSet;
+import io.github.open_policy_agent.opa.ast.types.RegoString;
+import io.github.open_policy_agent.opa.ast.types.RegoValue;
+import io.github.open_policy_agent.opa.rego.EvaluationContext;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class AggregateBuiltinsTest {
+
+  private final AggregateBuiltins aggregateBuiltins = new AggregateBuiltins();
+  private final EvaluationContext ctx = new EvaluationContext.Builder().build();
+
+  @Test
+  public void testMember2Set() {
+    RegoSet set = new RegoSet(false);
+    set.addValue(RegoInt32.of(1));
+
+    RegoValue resTrue = aggregateBuiltins.member2(ctx, new RegoValue[] {RegoInt32.of(1), set});
+    assertEquals(RegoBoolean.TRUE, resTrue);
+
+    RegoValue resFalse = aggregateBuiltins.member2(ctx, new RegoValue[] {RegoInt32.of(2), set});
+    assertEquals(RegoBoolean.FALSE, resFalse);
+  }
+
+  @Test
+  public void testMember2Array() {
+    RegoArray arr = new RegoArray(List.of(new RegoString("a"), new RegoString("b")));
+
+    assertEquals(RegoBoolean.TRUE, aggregateBuiltins.member2(ctx, new RegoValue[] {new RegoString("a"), arr}));
+    assertEquals(RegoBoolean.FALSE, aggregateBuiltins.member2(ctx, new RegoValue[] {new RegoString("c"), arr}));
+  }
+
+  @Test
+  public void testMember2Object() {
+    RegoObject obj = new RegoObject(Map.of(new RegoString("foo"), RegoInt32.of(1)));
+
+    assertEquals(RegoBoolean.TRUE, aggregateBuiltins.member2(ctx, new RegoValue[] {RegoInt32.of(1), obj}));
+    assertEquals(RegoBoolean.FALSE, aggregateBuiltins.member2(ctx, new RegoValue[] {new RegoString("foo"), obj}));
+  }
+
+  @Test
+  public void testMember2NonCollection() {
+    assertEquals(RegoBoolean.FALSE, aggregateBuiltins.member2(ctx, new RegoValue[] {RegoInt32.of(1), new RegoString("foo")}));
+  }
+
+  @Test
+  public void testMember3Object() {
+    RegoObject obj = new RegoObject(Map.of(new RegoString("foo"), RegoInt32.of(1)));
+
+    assertEquals(RegoBoolean.TRUE, aggregateBuiltins.member3(ctx, new RegoValue[] {new RegoString("foo"), RegoInt32.of(1), obj}));
+    assertEquals(RegoBoolean.FALSE, aggregateBuiltins.member3(ctx, new RegoValue[] {new RegoString("foo"), RegoInt32.of(2), obj}));
+    assertEquals(RegoBoolean.FALSE, aggregateBuiltins.member3(ctx, new RegoValue[] {new RegoString("bar"), RegoInt32.of(1), obj}));
+  }
+
+  @Test
+  public void testMember3Array() {
+    RegoArray arr = new RegoArray(List.of(new RegoString("one"), new RegoString("two")));
+
+    assertEquals(RegoBoolean.TRUE, aggregateBuiltins.member3(ctx, new RegoValue[] {RegoInt32.of(1), new RegoString("two"), arr}));
+    assertEquals(RegoBoolean.FALSE, aggregateBuiltins.member3(ctx, new RegoValue[] {RegoInt32.of(0), new RegoString("two"), arr}));
+    assertEquals(RegoBoolean.FALSE, aggregateBuiltins.member3(ctx, new RegoValue[] {RegoInt32.of(5), new RegoString("two"), arr}));
+    assertEquals(RegoBoolean.FALSE, aggregateBuiltins.member3(ctx, new RegoValue[] {new RegoString("1"), new RegoString("two"), arr}));
+  }
+
+  @Test
+  public void testMember3Set() {
+    RegoSet set = new RegoSet(false);
+    set.addValue(new RegoString("x"));
+
+    assertEquals(RegoBoolean.TRUE, aggregateBuiltins.member3(ctx, new RegoValue[] {new RegoString("x"), new RegoString("x"), set}));
+    assertEquals(RegoBoolean.FALSE, aggregateBuiltins.member3(ctx, new RegoValue[] {new RegoString("x"), new RegoString("y"), set}));
+  }
+
+  @Test
+  public void testMember3NonCollection() {
+    assertEquals(RegoBoolean.FALSE, aggregateBuiltins.member3(ctx, new RegoValue[] {RegoInt32.of(1), new RegoString("a"), new RegoString("bar")}));
+  }
+}


### PR DESCRIPTION
## Description
Implement `internal.member_2` and `internal.member_3` OPA builtins backing Rego `in` membership operator expressions.

- `internal.member_2(x, collection)`: Checks if item `x` is contained in a Set, Array, or Object values. Returns `false` for non-collection operands.
- `internal.member_3(key, value, collection)`: Checks if `key` and `value` match in an Object, Array (0-based integer index), or Set (`key == value`). Returns `false` for non-collection operands or out-of-bounds indices.

Fixes #138

## Testing
- Added unit tests in `AggregateBuiltinsTest.java` covering Sets, Arrays, Objects, and non-collections for both `internal.member_2` and `internal.member_3`.
- Verified all OPA compliance test cases pass via `./gradlew test`.