### PR TITLE
feat(evaluator): implement opa.runtime builtin (#142)

### DIFF
--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/BuiltinRegistry.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/BuiltinRegistry.java
@@ -16,6 +16,7 @@ import io.github.open_policy_agent.opa.ast.builtin.impls.ComparisonBuiltins;
 import io.github.open_policy_agent.opa.ast.builtin.impls.EncodingBuiltins;
 import io.github.open_policy_agent.opa.ast.builtin.impls.HexBuiltins;
 import io.github.open_policy_agent.opa.ast.builtin.impls.ObjectBuiltins;
+import io.github.open_policy_agent.opa.ast.builtin.impls.OpaBuiltins;
 import io.github.open_policy_agent.opa.ast.builtin.impls.PrintBuiltins;
 import io.github.open_policy_agent.opa.ast.builtin.impls.SetBuiltins;
 import io.github.open_policy_agent.opa.ast.builtin.impls.StringBuiltins;
@@ -40,6 +41,7 @@ public class BuiltinRegistry {
     HexBuiltins.class,
     StringBuiltins.class,
     PrintBuiltins.class,
+    OpaBuiltins.class,
   };
 
   public static final Map<String, BiFunction<EvaluationContext, RegoValue[], RegoValue>>

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/OpaBuiltins.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/OpaBuiltins.java
@@ -1,14 +1,25 @@
 package io.github.open_policy_agent.opa.ast.builtin.impls;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
+import io.github.open_policy_agent.opa.ast.builtin.BuiltinError;
 import io.github.open_policy_agent.opa.ast.builtin.OpaBuiltin;
 import io.github.open_policy_agent.opa.ast.builtin.OpaDynamic;
 import io.github.open_policy_agent.opa.ast.builtin.OpaType;
+import io.github.open_policy_agent.opa.ast.types.RegoArray;
 import io.github.open_policy_agent.opa.ast.types.RegoObject;
+import io.github.open_policy_agent.opa.ast.types.RegoString;
 import io.github.open_policy_agent.opa.ast.types.RegoValue;
 import io.github.open_policy_agent.opa.rego.EvaluationContext;
 
+/**
+ * Implements OPA builtins under the {@code opa.*} namespace.
+ *
+ * <p>{@code opa.runtime} mirrors Go OPA's {@code topdown/runtime.go}: returns the evaluation
+ * context's runtime value when set, otherwise an empty object. When a {@code config} key is
+ * present, service credentials and crypto private keys are scrubbed before returning.
+ */
 public class OpaBuiltins {
 
   public static Map<String, BiFunction<EvaluationContext, RegoValue[], RegoValue>> builtins() {
@@ -30,22 +41,103 @@ public class OpaBuiltins {
               dynamic = @OpaDynamic(keyType = "string", valueType = "any")),
       nondeterministic = true)
   public RegoValue runtime(EvaluationContext ctx, RegoValue[] args) {
-    if (ctx != null && ctx.getNdBuiltinCache() != null) {
+    if (ctx.getNdBuiltinCache() != null) {
       RegoValue cachedValue = ctx.getNdBuiltinCache().get("opa.runtime", args);
       if (cachedValue != null) {
         return cachedValue;
       }
     }
 
-    RegoObject result = new RegoObject();
+    RegoValue result = resolveRuntime(ctx);
 
-    if (ctx != null) {
-      if (ctx.getNdBuiltinCache() != null) {
-        ctx.getNdBuiltinCache().put("opa.runtime", args, result);
-      }
-      ctx.recordNdCacheValue("opa.runtime", args, result);
+    if (ctx.getNdBuiltinCache() != null) {
+      ctx.getNdBuiltinCache().put("opa.runtime", args, result);
+    }
+    ctx.recordNdCacheValue("opa.runtime", args, result);
+
+    return result;
+  }
+
+  private static RegoValue resolveRuntime(EvaluationContext ctx) {
+    RegoValue runtime = ctx.getRuntime();
+    if (runtime == null) {
+      return new RegoObject();
+    }
+    return scrubConfigIfPresent(runtime);
+  }
+
+  /**
+   * When {@code config} is present, return a copy with credentials/keys scrubbed. Otherwise return
+   * the runtime value unchanged (matching Go OPA).
+   */
+  private static RegoValue scrubConfigIfPresent(RegoValue runtime) {
+    if (!(runtime instanceof RegoObject runtimeObj)) {
+      return runtime;
+    }
+    RegoValue configVal = runtimeObj.getProperty("config");
+    if (!(configVal instanceof RegoObject config)) {
+      return runtime;
+    }
+
+    RegoObject result = new RegoObject(new LinkedHashMap<>(runtimeObj.getProperties()));
+    result.setProperty("config", activeConfig(config));
+    return result;
+  }
+
+  /** Scrub secrets from config, matching Go {@code activeConfig}. */
+  private static RegoObject activeConfig(RegoObject config) {
+    RegoObject result = new RegoObject(new LinkedHashMap<>(config.getProperties()));
+
+    RegoValue services = result.getProperty("services");
+    if (services != null) {
+      result.setProperty("services", removeServiceCredentials(services));
+    }
+
+    RegoValue keys = result.getProperty("keys");
+    if (keys != null) {
+      result.setProperty("keys", removeCryptoKeys(keys));
     }
 
     return result;
+  }
+
+  private static RegoValue removeServiceCredentials(RegoValue services) {
+    if (services instanceof RegoObject map) {
+      RegoObject result = new RegoObject();
+      for (Map.Entry<RegoValue, RegoValue> entry : map.getProperties().entrySet()) {
+        result.setProp(entry.getKey(), removeKeys(entry.getValue(), "credentials"));
+      }
+      return result;
+    }
+    if (services instanceof RegoArray arr) {
+      RegoArray result = new RegoArray();
+      for (RegoValue value : arr.getValues()) {
+        result.addValue(removeKeys(value, "credentials"));
+      }
+      return result;
+    }
+    throw new BuiltinError("illegal service config type: " + services.getTypeName());
+  }
+
+  private static RegoValue removeCryptoKeys(RegoValue keys) {
+    if (!(keys instanceof RegoObject map)) {
+      throw new BuiltinError("illegal keys config type: " + keys.getTypeName());
+    }
+    RegoObject result = new RegoObject();
+    for (Map.Entry<RegoValue, RegoValue> entry : map.getProperties().entrySet()) {
+      result.setProp(entry.getKey(), removeKeys(entry.getValue(), "key", "private_key"));
+    }
+    return result;
+  }
+
+  private static RegoObject removeKeys(RegoValue value, String... keys) {
+    if (!(value instanceof RegoObject obj)) {
+      throw new BuiltinError("type assertion error");
+    }
+    RegoObject copy = new RegoObject(new LinkedHashMap<>(obj.getProperties()));
+    for (String key : keys) {
+      copy.getProperties().remove(new RegoString(key));
+    }
+    return copy;
   }
 }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/OpaBuiltins.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/OpaBuiltins.java
@@ -1,0 +1,51 @@
+package io.github.open_policy_agent.opa.ast.builtin.impls;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import io.github.open_policy_agent.opa.ast.builtin.OpaBuiltin;
+import io.github.open_policy_agent.opa.ast.builtin.OpaDynamic;
+import io.github.open_policy_agent.opa.ast.builtin.OpaType;
+import io.github.open_policy_agent.opa.ast.types.RegoObject;
+import io.github.open_policy_agent.opa.ast.types.RegoValue;
+import io.github.open_policy_agent.opa.rego.EvaluationContext;
+
+public class OpaBuiltins {
+
+  public static Map<String, BiFunction<EvaluationContext, RegoValue[], RegoValue>> builtins() {
+    OpaBuiltins instance = new OpaBuiltins();
+    return Map.of("opa.runtime", instance::runtime);
+  }
+
+  @OpaBuiltin(
+      name = "opa.runtime",
+      description = "Returns runtime environment and configuration metadata.",
+      categories = {"opa"},
+      args = {},
+      result =
+          @OpaType(
+              type = "object",
+              name = "output",
+              description =
+                  "includes a `config` key if OPA was started with a configuration file; an `env` key containing the environment variables that the OPA process was started with; includes `version` and `commit` keys containing the version and build commit of OPA.",
+              dynamic = @OpaDynamic(keyType = "string", valueType = "any")),
+      nondeterministic = true)
+  public RegoValue runtime(EvaluationContext ctx, RegoValue[] args) {
+    if (ctx != null && ctx.getNdBuiltinCache() != null) {
+      RegoValue cachedValue = ctx.getNdBuiltinCache().get("opa.runtime", args);
+      if (cachedValue != null) {
+        return cachedValue;
+      }
+    }
+
+    RegoObject result = new RegoObject();
+
+    if (ctx != null) {
+      if (ctx.getNdBuiltinCache() != null) {
+        ctx.getNdBuiltinCache().put("opa.runtime", args, result);
+      }
+      ctx.recordNdCacheValue("opa.runtime", args, result);
+    }
+
+    return result;
+  }
+}

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/rego/Engine.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/rego/Engine.java
@@ -527,6 +527,8 @@ public class Engine {
       private PreparedPlan preparedPlan;
       private PrintHook printHook;
       private boolean printHookSet;
+      private RegoValue runtime;
+      private boolean runtimeSet;
 
       private Builder withEngine(Engine engine) {
         this.engine = engine;
@@ -615,6 +617,18 @@ public class Engine {
       }
 
       /**
+       * Set the runtime object returned by OPA's {@code opa.runtime} builtin.
+       *
+       * @param runtime runtime metadata (env/version/commit/config), or null for empty
+       * @return this builder
+       */
+      public Builder withRuntime(RegoValue runtime) {
+        this.runtime = runtime;
+        this.runtimeSet = true;
+        return this;
+      }
+
+      /**
        * Build the PreparedQuery ready for evaluation. Captures the engine's current policy into a
        * pre-computed plan. Subsequent policy refreshes do not affect this PreparedQuery.
        *
@@ -638,6 +652,9 @@ public class Engine {
         }
         if (printHookSet) {
           contextBuilder.withPrintHook(printHook);
+        }
+        if (runtimeSet) {
+          contextBuilder.withRuntime(runtime);
         }
 
         // Warm up the plan by pre-computing expensive values

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/rego/EvaluationContext.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/rego/EvaluationContext.java
@@ -36,6 +36,7 @@ public class EvaluationContext {
   public final boolean sortSets;
   private final NdBuiltinCache ndBuiltinCache;
   private final PrintHook printHook;
+  private final RegoValue runtime;
 
   /**
    * Tracks non-deterministic builtin cache values used during this evaluation. Format:
@@ -59,6 +60,7 @@ public class EvaluationContext {
     this.sortSets = other.sortSets;
     this.ndBuiltinCache = other.ndBuiltinCache;
     this.printHook = other.printHook;
+    this.runtime = other.runtime;
   }
 
   private EvaluationContext(Builder builder) {
@@ -76,6 +78,7 @@ public class EvaluationContext {
     this.sortSets = builder.sortSets;
     this.ndBuiltinCache = builder.ndBuiltinCache;
     this.printHook = builder.printHook;
+    this.runtime = builder.runtime;
   }
 
   public boolean isStrictBuiltinErrors() {
@@ -97,6 +100,15 @@ public class EvaluationContext {
 
   public PrintHook getPrintHook() {
     return printHook;
+  }
+
+  /**
+   * Runtime metadata returned by the {@code opa.runtime} builtin, if configured.
+   *
+   * @return the runtime value, or null when unset (builtin returns an empty object)
+   */
+  public RegoValue getRuntime() {
+    return runtime;
   }
 
   public void traceEnterEvent(Stmt stmt, int blockIndex, int stmtIndex) {
@@ -195,6 +207,7 @@ public class EvaluationContext {
     private boolean sortSets = false;
     private NdBuiltinCache ndBuiltinCache;
     private PrintHook printHook = PrintHook.logger(new Logger.StandardLogger());
+    private RegoValue runtime;
 
     public Builder withStrictBuiltinErrors() {
       this.strictBuiltinErrors = true;
@@ -258,6 +271,18 @@ public class EvaluationContext {
 
     public Builder withPrintHook(PrintHook printHook) {
       this.printHook = printHook;
+      return this;
+    }
+
+    /**
+     * Set the runtime object returned by {@code opa.runtime}. Typically includes {@code env},
+     * {@code version}, {@code commit}, and optionally {@code config}.
+     *
+     * @param runtime runtime metadata, or null for an empty object
+     * @return this builder
+     */
+    public Builder withRuntime(RegoValue runtime) {
+      this.runtime = runtime;
       return this;
     }
 

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/builtin/NondeterministicAnnotationTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/builtin/NondeterministicAnnotationTest.java
@@ -17,7 +17,7 @@ public class NondeterministicAnnotationTest {
     // List of builtins that should be marked as nondeterministic
     List<String> expectedNondeterministicBuiltins =
         List.of(
-            "time.now_ns", "io.jwt.decode_verify", "io.jwt.encode_sign", "io.jwt.encode_sign_raw");
+            "time.now_ns", "io.jwt.decode_verify", "io.jwt.encode_sign", "io.jwt.encode_sign_raw", "opa.runtime");
 
     for (String builtinName : expectedNondeterministicBuiltins) {
       // Find the descriptor for this builtin

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/OpaBuiltinsTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/OpaBuiltinsTest.java
@@ -1,0 +1,31 @@
+package io.github.open_policy_agent.opa.ast.builtin.impls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import io.github.open_policy_agent.opa.ast.builtin.BuiltinRegistry;
+import io.github.open_policy_agent.opa.ast.types.RegoObject;
+import io.github.open_policy_agent.opa.ast.types.RegoValue;
+import io.github.open_policy_agent.opa.rego.EvaluationContext;
+
+public class OpaBuiltinsTest {
+
+  @Test
+  public void testOpaRuntimeBuiltinRegistered() {
+    BuiltinRegistry registry = BuiltinRegistry.allCapabilities();
+    assertTrue(registry.hasBuiltIn("opa.runtime"), "opa.runtime should be registered");
+  }
+
+  @Test
+  public void testOpaRuntimeReturnsRegoObject() {
+    OpaBuiltins opaBuiltins = new OpaBuiltins();
+    EvaluationContext ctx = new EvaluationContext.Builder().build();
+    RegoValue result = opaBuiltins.runtime(ctx, new RegoValue[0]);
+
+    assertNotNull(result);
+    assertTrue(result instanceof RegoObject);
+    assertEquals("object", result.getTypeName());
+  }
+}

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/OpaBuiltinsTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/OpaBuiltinsTest.java
@@ -1,31 +1,112 @@
 package io.github.open_policy_agent.opa.ast.builtin.impls;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import io.github.open_policy_agent.opa.ast.builtin.BuiltinRegistry;
 import io.github.open_policy_agent.opa.ast.types.RegoObject;
+import io.github.open_policy_agent.opa.ast.types.RegoString;
 import io.github.open_policy_agent.opa.ast.types.RegoValue;
+import io.github.open_policy_agent.opa.cache.NdBuiltinCache;
 import io.github.open_policy_agent.opa.rego.EvaluationContext;
 
 public class OpaBuiltinsTest {
 
+  private final OpaBuiltins opaBuiltins = new OpaBuiltins();
+
   @Test
   public void testOpaRuntimeBuiltinRegistered() {
     BuiltinRegistry registry = BuiltinRegistry.allCapabilities();
-    assertTrue(registry.hasBuiltIn("opa.runtime"), "opa.runtime should be registered");
+    assertTrue(registry.hasBuiltIn("opa.runtime"));
   }
 
   @Test
-  public void testOpaRuntimeReturnsRegoObject() {
-    OpaBuiltins opaBuiltins = new OpaBuiltins();
+  public void testOpaRuntimeUnsetReturnsEmptyObject() {
     EvaluationContext ctx = new EvaluationContext.Builder().build();
     RegoValue result = opaBuiltins.runtime(ctx, new RegoValue[0]);
 
-    assertNotNull(result);
-    assertTrue(result instanceof RegoObject);
-    assertEquals("object", result.getTypeName());
+    assertEquals(new RegoObject(), result);
+  }
+
+  @Test
+  public void testOpaRuntimeReturnsInjectedValue() {
+    RegoObject runtime = new RegoObject();
+    runtime.setProperty("version", new RegoString("1.0.0"));
+    runtime.setProperty("commit", new RegoString("abc123"));
+
+    EvaluationContext ctx = new EvaluationContext.Builder().withRuntime(runtime).build();
+    RegoValue result = opaBuiltins.runtime(ctx, new RegoValue[0]);
+
+    assertSame(runtime, result);
+  }
+
+  @Test
+  public void testOpaRuntimeScrubsServiceCredentialsAndKeys() {
+    RegoObject credentials = new RegoObject();
+    credentials.setProperty("bearer", new RegoString("secret-token"));
+
+    RegoObject service = new RegoObject();
+    service.setProperty("url", new RegoString("https://example.com"));
+    service.setProperty("credentials", credentials);
+
+    RegoObject services = new RegoObject();
+    services.setProperty("acmecorp", service);
+
+    RegoObject keyEntry = new RegoObject();
+    keyEntry.setProperty("algorithm", new RegoString("RS256"));
+    keyEntry.setProperty("key", new RegoString("PUBLIC"));
+    keyEntry.setProperty("private_key", new RegoString("PRIVATE"));
+
+    RegoObject keys = new RegoObject();
+    keys.setProperty("mykey", keyEntry);
+
+    RegoObject config = new RegoObject();
+    config.setProperty("services", services);
+    config.setProperty("keys", keys);
+
+    RegoObject runtime = new RegoObject();
+    runtime.setProperty("version", new RegoString("1.0.0"));
+    runtime.setProperty("config", config);
+
+    EvaluationContext ctx = new EvaluationContext.Builder().withRuntime(runtime).build();
+    RegoObject result = (RegoObject) opaBuiltins.runtime(ctx, new RegoValue[0]);
+
+    RegoObject scrubbedService =
+        (RegoObject)
+            ((RegoObject) ((RegoObject) result.getProperty("config")).getProperty("services"))
+                .getProperty("acmecorp");
+    assertEquals(new RegoString("https://example.com"), scrubbedService.getProperty("url"));
+    assertNull(scrubbedService.getProperty("credentials"));
+
+    RegoObject scrubbedKey =
+        (RegoObject)
+            ((RegoObject) ((RegoObject) result.getProperty("config")).getProperty("keys"))
+                .getProperty("mykey");
+    assertEquals(new RegoString("RS256"), scrubbedKey.getProperty("algorithm"));
+    assertNull(scrubbedKey.getProperty("key"));
+    assertNull(scrubbedKey.getProperty("private_key"));
+
+    // Original runtime must not be mutated
+    assertEquals(credentials, service.getProperty("credentials"));
+    assertEquals(new RegoString("PRIVATE"), keyEntry.getProperty("private_key"));
+  }
+
+  @Test
+  public void testOpaRuntimeUsesNdBuiltinCache() {
+    RegoObject runtime = new RegoObject();
+    runtime.setProperty("version", new RegoString("cached"));
+
+    NdBuiltinCache cache = new NdBuiltinCache(10, 60);
+    EvaluationContext ctx =
+        new EvaluationContext.Builder().withRuntime(runtime).withNdBuiltinCache(cache).build();
+
+    RegoValue first = opaBuiltins.runtime(ctx, new RegoValue[0]);
+    RegoValue second = opaBuiltins.runtime(ctx, new RegoValue[0]);
+
+    assertSame(first, second);
+    assertEquals(1, ctx.getNdCacheValues().get("opa.runtime").size());
   }
 }


### PR DESCRIPTION
Fixes #142

### Summary
This PR implements the `opa.runtime` built-in function in `OpaBuiltins`, registers it in `BuiltinRegistry.BUILTIN_CLASSES`, and marks it as nondeterministic for `nd_builtin_cache` support.

### Changes
- Implemented `opa.runtime` in `OpaBuiltins` under `io.github.open_policy_agent.opa.ast.builtin.impls`.
- Annotated `opa.runtime` with `@OpaBuiltin(name = "opa.runtime", ..., nondeterministic = true)`.
- Registered `OpaBuiltins.class` in `BuiltinRegistry.BUILTIN_CLASSES`.
- Added unit tests in `OpaBuiltinsTest` and updated `NondeterministicAnnotationTest`.

### Verification
- Tested with `./gradlew test` using JDK 17: all test suites pass.