### PR TITLE
fix(evaluator): add missing UriBuiltins import

### DIFF
--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/BuiltinRegistry.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ast/builtin/BuiltinRegistry.java
@@ -21,6 +21,7 @@ import io.github.open_policy_agent.opa.ast.builtin.impls.PrintBuiltins;
 import io.github.open_policy_agent.opa.ast.builtin.impls.SetBuiltins;
 import io.github.open_policy_agent.opa.ast.builtin.impls.StringBuiltins;
 import io.github.open_policy_agent.opa.ast.builtin.impls.TypeBuiltins;
+import io.github.open_policy_agent.opa.ast.builtin.impls.UriBuiltins;
 import io.github.open_policy_agent.opa.ast.types.RegoValue;
 import io.github.open_policy_agent.opa.rego.Capabilities;
 import io.github.open_policy_agent.opa.rego.EvaluationContext;


### PR DESCRIPTION
`main` currently does not compile:

```
BuiltinRegistry.java:42: error: cannot find symbol
      UriBuiltins.class,
  symbol: class UriBuiltins
```

`BUILTIN_CLASSES` references `UriBuiltins`, which lives in the `impls` subpackage and so needs an explicit import. This adds it — one line, no behaviour change.

### How it slipped in

Two individually green PRs that break in combination:

- #156 branched from a commit where `BuiltinRegistry` still had `import ...ast.builtin.impls.*;`, so its one-line `+ UriBuiltins.class,` compiled there.
- #171 then replaced that wildcard with explicit imports.

The merge had no textual conflict, so the reference survived without an import. `pull-request.yml` is `on: pull_request` only and no workflow builds `main` on push, so nothing flagged it — it surfaces on unrelated PRs instead (e.g. #187).

Worth considering separately: adding `push: branches: [main]` to the build workflow so a red `main` is caught directly.

### Testing

`./gradlew build` passes on this branch (compile, Checkstyle, PMD, all module tests). Verified `main` at 6f5e5dc fails the same way without this change.
