### PR TITLE
tracing: Make coverage range aware

### DIFF
--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/Location.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/Location.java
@@ -13,10 +13,21 @@ public class Location implements LocationStmt {
 
   private int row; // row in the source file where this statement originated
 
+  private int endCol; // column one past the last rune of this statement's source text
+
+  private int endRow; // row of the last rune of this statement's source text
+
   public Location(int file, int col, int row) {
+    // For callers that do not have end location data.
+    this(file, col, row, col, row);
+  }
+
+  public Location(int file, int col, int row, int endCol, int endRow) {
     this.file = file;
     this.col = col;
     this.row = row;
+    this.endCol = endCol;
+    this.endRow = endRow;
   }
 
   public Location() {}
@@ -48,12 +59,21 @@ public class Location implements LocationStmt {
     return this;
   }
 
+  public int getEndCol() {
+    return endCol;
+  }
+
+  public int getEndRow() {
+    return endRow;
+  }
+
   @Override
-  public Location setLocation(int file, int row, int col) {
+  public void setLocation(int file, int row, int col, int endRow, int endCol) {
     this.file = file;
     this.col = col;
     this.row = row;
-    return this;
+    this.endCol = endCol;
+    this.endRow = endRow;
   }
 
   @Override

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/Location.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/Location.java
@@ -83,22 +83,27 @@ public class Location implements LocationStmt {
 
   @Override
   public boolean equals(Object o) {
-      if (this == o) {
-          return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-          return false;
-      }
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
 
     Location location = (Location) o;
-
-      if (file != location.file) {
-          return false;
-      }
-      if (col != location.col) {
-          return false;
-      }
-    return row == location.row;
+    if (file != location.file) {
+      return false;
+    }
+    if (col != location.col) {
+      return false;
+    }
+    if (row != location.row) {
+      return false;
+    }
+    if (endCol != location.endCol) {
+      return false;
+    }
+    return endRow == location.endRow;
   }
 
   @Override
@@ -106,11 +111,19 @@ public class Location implements LocationStmt {
     int result = file;
     result = 31 * result + col;
     result = 31 * result + row;
+    result = 31 * result + endCol;
+    result = 31 * result + endRow;
     return result;
   }
 
   @Override
   public String toString() {
-    return "Location{" + "file=" + file + ", col=" + col + ", row=" + row + '}';
+    return "Location{"
+        + "file=" + file
+        + ", col=" + col
+        + ", row=" + row
+        + ", endCol=" + endCol
+        + ", endRow=" + endRow
+        + '}';
   }
 }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/BaseStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/BaseStmt.java
@@ -95,7 +95,13 @@ public abstract class BaseStmt implements Stmt {
         if (col != baseStmt.col) {
             return false;
         }
-        return row == baseStmt.row;
+        if (row != baseStmt.row) {
+            return false;
+        }
+        if (endCol != baseStmt.endCol) {
+            return false;
+        }
+        return endRow == baseStmt.endRow;
     }
 
     @Override
@@ -103,6 +109,8 @@ public abstract class BaseStmt implements Stmt {
         int result = file;
         result = 31 * result + col;
         result = 31 * result + row;
+        result = 31 * result + endCol;
+        result = 31 * result + endRow;
         return result;
     }
 }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/BaseStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/BaseStmt.java
@@ -8,32 +8,36 @@ public abstract class BaseStmt implements Stmt {
     private int file; // index of source filename
     private int col; // column in the source file
     private int row; // row in the source file
+    private int endCol; // column one past the last rune of the source text
+    private int endRow; // row of the last rune of the source text
     private Location cachedLocation;
 
     protected BaseStmt(int file, int col, int row) {
         this.file = file;
         this.col = col;
         this.row = row;
+        this.endCol = col;
+        this.endRow = row;
     }
 
     protected BaseStmt() {
     }
 
     @Override
-    public Location setLocation(int file, int row, int col) {
+    public void setLocation(int file, int row, int col, int endRow, int endCol) {
         this.file = file;
         this.col = col;
         this.row = row;
-        Location loc = new Location(file, col, row);
-        this.cachedLocation = loc;
-        return loc;
+        this.endCol = endCol;
+        this.endRow = endRow;
+        this.cachedLocation = new Location(file, col, row, endCol, endRow);;
     }
 
     @Override
     public Location getLocation() {
         Location loc = cachedLocation;
         if (loc == null) {
-            loc = new Location(file, col, row);
+            loc = new Location(file, col, row, endCol, endRow);
             cachedLocation = loc;
         }
         return loc;

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/LocationStmt.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/stmts/LocationStmt.java
@@ -3,7 +3,17 @@ package io.github.open_policy_agent.opa.ir.stmts;
 import io.github.open_policy_agent.opa.ir.Location;
 
 public interface LocationStmt {
-    Location setLocation(int file, int row, int col);
+    /**
+     * Sets the  source location range for statement.
+     */
+    void setLocation(int file, int row, int col, int endRow, int endCol);
+
+    /**
+     * Sets the source location without an explicit end
+     */
+    default void setLocation(int file, int row, int col) {
+        setLocation(file, row, col, row, col);
+    }
 
     Location getLocation();
 }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageProfiler.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageProfiler.java
@@ -5,25 +5,26 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import io.github.open_policy_agent.opa.ir.Location;
 
 /**
- * {@link Profiler} implementation that records the source rows touched during evaluation, for use
- * as Rego line-coverage data.
+ * {@link Profiler} implementation that records the source ranges touched during evaluation, for use
+ * as Rego coverage data.
  *
- * <p>Coverage is tracked as a map of file index (per the policy's static file table) to the set
- * of source rows that were executed. The column is intentionally discarded: coverage is
- * line-granular.
+ * <p>Coverage is tracked as a map of file index (per the policy's static file table) to the set of
+ * source {@link Range}s that were executed. Some statements start and finish on the same line, some
+ * lines have more than one statement.
  *
- * <p>Only locations from statements that the evaluator dispatched are recorded. The Rego compiler
- * may emit statements that the evaluator never reaches — e.g. statements that follow an earlier
- * statement which short-circuited the block. Those rows are reported as not-covered, which
+ * <p>Ranges from statements that the evaluator ran are recorded. The Rego compiler may
+ * emit statements that the evaluator runs, e.g. statements following an earlier
+ * one which exited the block. Those ranges are reported as not-covered, which
  * matches the expected coverage semantics.
  *
- * If only location line tracing is required, this is a more performant alternative to {@link DurationProfiler}
+ * <p>If only location tracing is required, this is a more performant alternative to {@link DurationProfiler}
  */
 public class CoverageProfiler implements Profiler {
-  private final Map<Integer, Set<Integer>> hitsByFile = new HashMap<>();
+  private final Map<Integer, Set<Range>> hitsByFile = new HashMap<>();
 
   @Override
   public void addStart() {
@@ -35,14 +36,32 @@ public class CoverageProfiler implements Profiler {
       if (location == null) {
           return;
       }
-    hitsByFile.computeIfAbsent(location.getFile(), k -> new HashSet<>()).add(location.getRow());
+    hitsByFile.computeIfAbsent(location.getFile(), k -> new HashSet<>()).add(Range.of(location));
   }
 
   /**
-   * @return per-file map of executed source rows. Outer key is the file index in the policy's
-   *     static file table; inner value is the set of source rows that were executed.
+   * @return per-file map of executed source ranges. Outer key is the file index in the policy's
+   *     static file table; inner value is the set of source ranges that were executed.
+   */
+  public Map<Integer, Set<Range>> getCoveredRanges() {
+    return Collections.unmodifiableMap(hitsByFile);
+  }
+
+  /**
+   * @return map of executed source rows (per file), derived from the recorded ranges, for any
+   *     line-based consumers. Use {@link #getCoveredRanges()} for column-precise coverage.
    */
   public Map<Integer, Set<Integer>> getCoveredLines() {
-    return Collections.unmodifiableMap(hitsByFile);
+    Map<Integer, Set<Integer>> rowsByFile = new HashMap<>();
+    for (Map.Entry<Integer, Set<Range>> entry : hitsByFile.entrySet()) {
+      Set<Integer> rows = new TreeSet<>();
+      for (Range range : entry.getValue()) {
+        for (int row = range.getStart().getRow(); row <= range.getEnd().getRow(); row++) {
+          rows.add(row);
+        }
+      }
+      rowsByFile.put(entry.getKey(), rows);
+    }
+    return Collections.unmodifiableMap(rowsByFile);
   }
 }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageProfiler.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageProfiler.java
@@ -56,7 +56,7 @@ public class CoverageProfiler implements Profiler {
     for (Map.Entry<Integer, Set<Range>> entry : hitsByFile.entrySet()) {
       Set<Integer> rows = new TreeSet<>();
       for (Range range : entry.getValue()) {
-        for (int row = range.getStart().getRow(); row <= range.getEnd().getRow(); row++) {
+        for (int row = range.start().getRow(); row <= range.end().getRow(); row++) {
           rows.add(row);
         }
       }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/Position.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/Position.java
@@ -1,0 +1,53 @@
+package io.github.open_policy_agent.opa.tracing;
+
+/** A {@code (row, col)} position in a source file, mirroring {@code Position} in OPA's {@code v1/cover}. */
+public final class Position implements Comparable<Position> {
+  private final int row;
+  private final int col;
+
+  public Position(int row, int col) {
+    this.row = row;
+    this.col = col;
+  }
+
+  public int getRow() {
+    return row;
+  }
+
+  public int getCol() {
+    return col;
+  }
+
+  @Override
+  public int compareTo(Position other) {
+    if (row != other.row) {
+      return Integer.compare(row, other.row);
+    }
+    return Integer.compare(col, other.col);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Position position = (Position) o;
+
+    return row == position.row && col == position.col;
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * row + col;
+  }
+
+  @Override
+  public String toString() {
+    return "(" + row + "," + col + ")";
+  }
+}

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/Range.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/Range.java
@@ -1,0 +1,78 @@
+package io.github.open_policy_agent.opa.tracing;
+
+import io.github.open_policy_agent.opa.ir.Location;
+
+/**
+ * A source range spanning {@code [start, end)}, mirroring {@code Range} in OPA's {@code v1/cover}.
+ */
+public final class Range implements Comparable<Range> {
+  private final Position start;
+  private final Position end;
+
+  public Range(Position start, Position end) {
+    this.start = start;
+    this.end = end;
+  }
+
+  public Range(int startRow, int startCol, int endRow, int endCol) {
+    this(new Position(startRow, startCol), new Position(endRow, endCol));
+  }
+
+  /** Builds a range from a statement {@link Location}
+   * (end location based on start+text) */
+  public static Range of(Location location) {
+    return new Range(
+        new Position(location.getRow(), location.getCol()),
+        new Position(location.getEndRow(), location.getEndCol()));
+  }
+
+  public Position getStart() {
+    return start;
+  }
+
+  public Position getEnd() {
+    return end;
+  }
+
+  // Mirrors Range.contains in OPA's v1/cover: other is fully contained when this range starts at
+  // or before it and ends at or after it (row compared before column, via Position.compareTo).
+  public boolean contains(Range other) {
+    return start.compareTo(other.start) <= 0 && end.compareTo(other.end) >= 0;
+  }
+
+  @Override
+  public int compareTo(Range other) {
+    int byStart = start.compareTo(other.start);
+
+    if (byStart != 0) {
+      return byStart;
+    }
+
+    return end.compareTo(other.end);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Range range = (Range) o;
+
+    return start.equals(range.start) && end.equals(range.end);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * start.hashCode() + end.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "Range{start=" + start + ", end=" + end + "}";
+  }
+}

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/Range.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/Range.java
@@ -5,39 +5,20 @@ import io.github.open_policy_agent.opa.ir.Location;
 /**
  * A source range spanning {@code [start, end)}, mirroring {@code Range} in OPA's {@code v1/cover}.
  */
-public final class Range implements Comparable<Range> {
-  private final Position start;
-  private final Position end;
-
-  public Range(Position start, Position end) {
-    this.start = start;
-    this.end = end;
-  }
+public record Range(Position start, Position end) implements Comparable<Range> {
 
   public Range(int startRow, int startCol, int endRow, int endCol) {
     this(new Position(startRow, startCol), new Position(endRow, endCol));
   }
 
-  /** Builds a range from a statement {@link Location}
-   * (end location based on start+text) */
+  /**
+   * Builds a range from a statement {@link Location}
+   * (end location based on start+text)
+   */
   public static Range of(Location location) {
     return new Range(
-        new Position(location.getRow(), location.getCol()),
-        new Position(location.getEndRow(), location.getEndCol()));
-  }
-
-  public Position getStart() {
-    return start;
-  }
-
-  public Position getEnd() {
-    return end;
-  }
-
-  // Mirrors Range.contains in OPA's v1/cover: other is fully contained when this range starts at
-  // or before it and ends at or after it (row compared before column, via Position.compareTo).
-  public boolean contains(Range other) {
-    return start.compareTo(other.start) <= 0 && end.compareTo(other.end) >= 0;
+            new Position(location.getRow(), location.getCol()),
+            new Position(location.getEndRow(), location.getEndCol()));
   }
 
   @Override
@@ -51,28 +32,9 @@ public final class Range implements Comparable<Range> {
     return end.compareTo(other.end);
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    Range range = (Range) o;
-
-    return start.equals(range.start) && end.equals(range.end);
-  }
-
-  @Override
-  public int hashCode() {
-    return 31 * start.hashCode() + end.hashCode();
-  }
-
-  @Override
-  public String toString() {
-    return "Range{start=" + start + ", end=" + end + "}";
+  // Mirrors Range.contains in OPA's v1/cover: other is fully contained when this range starts at
+  // or before it and ends at or after it (row compared before column, via Position.compareTo).
+  boolean contains(Range other) {
+    return start.compareTo(other.start) <= 0 && end.compareTo(other.end) >= 0;
   }
 }

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/PolicyTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/PolicyTest.java
@@ -131,6 +131,32 @@ class PolicyTest {
   }
 
   @Test
+  public void testPolicyDeserialization_endLocations() throws IOException {
+    // Fixture built by `opa build -t plan` from an OPA carrying IR end locations
+    // (https://github.com/open-policy-agent/opa/pull/9007). The rule `p := 7` is on line 3,
+    // cols 1-7, so end_row/end_col differ from row/col — a swapped end fails these assertions.
+    File jsonFile =
+        new File(
+            Objects.requireNonNull(
+                    getClass()
+                        .getClassLoader()
+                        .getResource("ir/testdata/policy-end-locations.json"))
+                .getFile());
+
+    Policy policy = policyReader.read(Files.newInputStream(jsonFile.toPath()));
+
+    Location loc =
+        policy.getFuncs().getFuncs().get(0).getBlocks().get(0).getStmts().get(0).getLocation();
+
+    assertEquals(3, loc.getRow());
+    assertEquals(1, loc.getCol());
+    assertEquals(3, loc.getEndRow());
+    assertEquals(7, loc.getEndCol());
+    // equals now includes the end, so the whole range round-trips (constructor is file,col,row,...).
+    assertEquals(new Location(0, 1, 3, 7, 3), loc);
+  }
+
+  @Test
   public void testPolicyDeserialization_staticsOnlyStrings() throws IOException {
     File jsonFile =
         new File(

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/tracing/RangeTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/tracing/RangeTest.java
@@ -12,10 +12,10 @@ class RangeTest {
     Location loc = new Location(0, 2, 5, 14, 5); // file, col, row, endCol, endRow
     Range range = Range.of(loc);
 
-    assertEquals(5, range.getStart().getRow());
-    assertEquals(2, range.getStart().getCol());
-    assertEquals(5, range.getEnd().getRow());
-    assertEquals(14, range.getEnd().getCol());
+    assertEquals(5, range.start().getRow());
+    assertEquals(2, range.start().getCol());
+    assertEquals(5, range.end().getRow());
+    assertEquals(14, range.end().getCol());
   }
 
   @Test

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/tracing/RangeTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/tracing/RangeTest.java
@@ -1,0 +1,54 @@
+package io.github.open_policy_agent.opa.tracing;
+
+import io.github.open_policy_agent.opa.ir.Location;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RangeTest {
+
+  @Test
+  void of_derivesStartAndEndFromLocation() {
+    Location loc = new Location(0, 2, 5, 14, 5); // file, col, row, endCol, endRow
+    Range range = Range.of(loc);
+
+    assertEquals(5, range.getStart().getRow());
+    assertEquals(2, range.getStart().getCol());
+    assertEquals(5, range.getEnd().getRow());
+    assertEquals(14, range.getEnd().getCol());
+  }
+
+  @Test
+  void contains_requiresFullContainment() {
+    Range outer = new Range(5, 1, 5, 20);
+
+    assertTrue(outer.contains(new Range(5, 4, 5, 10)));
+    assertTrue(outer.contains(outer));
+    // Same row but the column span extends past the outer range's end column.
+    assertFalse(outer.contains(new Range(5, 4, 5, 24)));
+    // Same row but starts before the outer range's start column.
+    assertFalse(new Range(5, 5, 5, 20).contains(new Range(5, 2, 5, 10)));
+  }
+
+  @Test
+  void compareTo_ordersByStartThenEnd() {
+    Range a = new Range(5, 1, 5, 10);
+    Range b = new Range(5, 2, 5, 10);
+    Range c = new Range(6, 1, 6, 10);
+
+    assertTrue(a.compareTo(b) < 0);
+    assertTrue(b.compareTo(c) < 0);
+    assertEquals(0, a.compareTo(new Range(5, 1, 5, 10)));
+  }
+
+  @Test
+  void equalsAndHashCode_useAllFourCoordinates() {
+    Range a = new Range(5, 1, 5, 10);
+    Range same = new Range(5, 1, 5, 10);
+    Range different = new Range(5, 1, 5, 11);
+
+    assertEquals(a, same);
+    assertEquals(a.hashCode(), same.hashCode());
+    assertNotEquals(a, different);
+  }
+}

--- a/opa-evaluator/src/test/resources/ir/testdata/policy-end-locations.json
+++ b/opa-evaluator/src/test/resources/ir/testdata/policy-end-locations.json
@@ -1,0 +1,215 @@
+{
+  "static": {
+    "strings": [
+      {
+        "value": "result"
+      },
+      {
+        "value": "7"
+      }
+    ],
+    "files": [
+      {
+        "value": "policy.rego"
+      }
+    ]
+  },
+  "plans": {
+    "plans": [
+      {
+        "name": "endloc/p",
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "type": "CallStmt",
+                "stmt": {
+                  "func": "g0.data.endloc.p",
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "result": 2,
+                  "file": 0,
+                  "col": 0,
+                  "row": 0,
+                  "end_col": 0,
+                  "end_row": 0
+                }
+              },
+              {
+                "type": "AssignVarStmt",
+                "stmt": {
+                  "source": {
+                    "type": "local",
+                    "value": 2
+                  },
+                  "target": 3,
+                  "file": 0,
+                  "col": 0,
+                  "row": 0,
+                  "end_col": 0,
+                  "end_row": 0
+                }
+              },
+              {
+                "type": "MakeObjectStmt",
+                "stmt": {
+                  "target": 4,
+                  "file": 0,
+                  "col": 0,
+                  "row": 0,
+                  "end_col": 0,
+                  "end_row": 0
+                }
+              },
+              {
+                "type": "ObjectInsertStmt",
+                "stmt": {
+                  "key": {
+                    "type": "string_index",
+                    "value": 0
+                  },
+                  "value": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "object": 4,
+                  "file": 0,
+                  "col": 0,
+                  "row": 0,
+                  "end_col": 0,
+                  "end_row": 0
+                }
+              },
+              {
+                "type": "ResultSetAddStmt",
+                "stmt": {
+                  "value": 4,
+                  "file": 0,
+                  "col": 0,
+                  "row": 0,
+                  "end_col": 0,
+                  "end_row": 0
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "funcs": {
+    "funcs": [
+      {
+        "name": "g0.data.endloc.p",
+        "params": [
+          0,
+          1
+        ],
+        "return": 2,
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "type": "ResetLocalStmt",
+                "stmt": {
+                  "target": 3,
+                  "file": 0,
+                  "col": 1,
+                  "row": 3,
+                  "end_col": 7,
+                  "end_row": 3
+                }
+              },
+              {
+                "type": "MakeNumberRefStmt",
+                "stmt": {
+                  "file": 0,
+                  "col": 1,
+                  "row": 3,
+                  "end_col": 7,
+                  "end_row": 3,
+                  "index": 1,
+                  "Index": 1,
+                  "target": 4
+                }
+              },
+              {
+                "type": "AssignVarOnceStmt",
+                "stmt": {
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 3,
+                  "file": 0,
+                  "col": 1,
+                  "row": 3,
+                  "end_col": 7,
+                  "end_row": 3
+                }
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "type": "IsDefinedStmt",
+                "stmt": {
+                  "source": 3,
+                  "file": 0,
+                  "col": 1,
+                  "row": 3,
+                  "end_col": 7,
+                  "end_row": 3
+                }
+              },
+              {
+                "type": "AssignVarOnceStmt",
+                "stmt": {
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2,
+                  "file": 0,
+                  "col": 1,
+                  "row": 3,
+                  "end_col": 7,
+                  "end_row": 3
+                }
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "type": "ReturnLocalStmt",
+                "stmt": {
+                  "source": 2,
+                  "file": 0,
+                  "col": 1,
+                  "row": 3,
+                  "end_col": 7,
+                  "end_row": 3
+                }
+              }
+            ]
+          }
+        ],
+        "path": [
+          "g0",
+          "endloc",
+          "p"
+        ]
+      }
+    ]
+  }
+}

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/OpaCoverageReport.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/OpaCoverageReport.java
@@ -75,8 +75,8 @@ public final class OpaCoverageReport {
     sorted.sort(Range::compareTo);
     for (Range range : sorted) {
       ObjectNode rangeNode = array.addObject();
-      writePosition(rangeNode.putObject("start"), range.getStart());
-      writePosition(rangeNode.putObject("end"), range.getEnd());
+      writePosition(rangeNode.putObject("start"), range.start());
+      writePosition(rangeNode.putObject("end"), range.end());
     }
   }
 

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/OpaCoverageReport.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/OpaCoverageReport.java
@@ -1,19 +1,21 @@
 package io.github.open_policy_agent.opa.jackson;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.open_policy_agent.opa.tracing.CoverageProfiler;
+import io.github.open_policy_agent.opa.tracing.Position;
+import io.github.open_policy_agent.opa.tracing.Range;
 
 /**
- * Serializes a {@link CoverageProfiler}'s collected line coverage into the JSON shape produced by
- * OPA's {@code opa eval --coverage} command.
+ * Serializes a {@link CoverageProfiler}'s collected coverage into the JSON shape produced by OPA's
+ * {@code opa eval --coverage} command.
  *
  * <p>Output structure:
  *
@@ -21,18 +23,16 @@ import io.github.open_policy_agent.opa.tracing.CoverageProfiler;
  * {
  *   "files": {
  *     "policy.rego": {
- *       "covered": [
- *         { "start": { "row": 5 }, "end": { "row": 5 } },
- *         { "start": { "row": 8 }, "end": { "row": 10 } }
- *       ]
+ *       "covered": [ { "start": { "row": 5, "col": 2 }, "end": { "row": 5, "col": 14 } } ]
  *     }
  *   }
  * }
  * }</pre>
  *
- * <p>Contiguous source rows are coalesced into a single range. File indices that fall outside the
- * provided filename list are skipped silently — those typically come from synthetic statements
- * with no source mapping.
+ * <p>Each executed statement range is emitted individually (sorted by position, not coalesced),
+ * matching OPA's {@code v1/cover} report; a range's column is omitted when zero. File indices that
+ * fall outside the provided filename list are skipped silently — those typically come from
+ * synthetic statements with no source mapping.
  */
 public final class OpaCoverageReport {
 
@@ -42,7 +42,7 @@ public final class OpaCoverageReport {
    * Build the OPA-format coverage report.
    *
    * @param profiler the profiler that recorded coverage during evaluation
-   * @param filenames file index -> filename mapping, typically obtained via
+   * @param filenames file index -&gt; filename mapping, typically obtained via
    *     {@code policy.getStaticField().getFiles()} mapped to {@code StringConst::getValue}
    * @return a Jackson {@link ObjectNode} with the OPA coverage shape
    */
@@ -50,53 +50,41 @@ public final class OpaCoverageReport {
     ObjectNode root = JsonNodeFactory.instance.objectNode();
     ObjectNode filesNode = root.putObject("files");
 
-    Map<Integer, Set<Integer>> hitsByFile = profiler.getCoveredLines();
+    Map<Integer, Set<Range>> coveredByFile = profiler.getCoveredRanges();
 
-    List<Integer> fileIndices = new ArrayList<>(hitsByFile.keySet());
+    List<Integer> fileIndices = new ArrayList<>(coveredByFile.keySet());
     Collections.sort(fileIndices);
 
     for (int fileIndex : fileIndices) {
       if (fileIndex < 0 || fileIndex >= filenames.size()) {
         continue;
       }
-      Set<Integer> rows = hitsByFile.get(fileIndex);
-      if (rows == null || rows.isEmpty()) {
+      Set<Range> covered = coveredByFile.get(fileIndex);
+      if (covered == null || covered.isEmpty()) {
         continue;
       }
-
       ObjectNode fileEntry = filesNode.putObject(filenames.get(fileIndex));
-      ArrayNode coveredArray = fileEntry.putArray("covered");
-      for (int[] range : coalesceRanges(rows)) {
-        ObjectNode rangeNode = coveredArray.addObject();
-        rangeNode.putObject("start").put("row", range[0]);
-        rangeNode.putObject("end").put("row", range[1]);
-      }
+      writeRanges(fileEntry.putArray("covered"), covered);
     }
 
     return root;
   }
 
-  /** Coalesce a set of row numbers into inclusive [start, end] ranges. */
-  static List<int[]> coalesceRanges(Set<Integer> rows) {
-    TreeSet<Integer> sorted = new TreeSet<>(rows);
-    List<int[]> ranges = new ArrayList<>();
-    int start = -1;
-    int end = -1;
-    for (int row : sorted) {
-      if (start == -1) {
-        start = row;
-        end = row;
-      } else if (row == end + 1) {
-        end = row;
-      } else {
-        ranges.add(new int[] {start, end});
-        start = row;
-        end = row;
-      }
+  private static void writeRanges(ArrayNode array, Collection<Range> ranges) {
+    List<Range> sorted = new ArrayList<>(ranges);
+    sorted.sort(Range::compareTo);
+    for (Range range : sorted) {
+      ObjectNode rangeNode = array.addObject();
+      writePosition(rangeNode.putObject("start"), range.getStart());
+      writePosition(rangeNode.putObject("end"), range.getEnd());
     }
-    if (start != -1) {
-      ranges.add(new int[] {start, end});
+  }
+
+  /** Writes a position. Column is omitted when zero, matching OPA's {@code col,omitempty}. */
+  private static void writePosition(ObjectNode node, Position position) {
+    node.put("row", position.getRow());
+    if (position.getCol() != 0) {
+      node.put("col", position.getCol());
     }
-    return ranges;
   }
 }

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/StmtDeserializer.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/StmtDeserializer.java
@@ -129,7 +129,17 @@ class StmtDeserializer extends JsonDeserializer<Stmt> {
     JsonNode col = stmtNode.get("col");
 
     if (file != null && row != null && col != null) {
-      stmt.setLocation(file.asInt(), row.asInt(), col.asInt());
+      // end_row/end_col were added to the IR later, in OPA 1.20.0
+      // (PR open-policy-agent/opa#9007).
+      // In older plans, the 3-arg setLocation collapses the range to a point,
+      // degrading coverage to line granularity.
+      JsonNode endRow = stmtNode.get("end_row");
+      JsonNode endCol = stmtNode.get("end_col");
+      if (endRow != null && endCol != null) {
+        stmt.setLocation(file.asInt(), row.asInt(), col.asInt(), endRow.asInt(), endCol.asInt());
+      } else {
+        stmt.setLocation(file.asInt(), row.asInt(), col.asInt());
+      }
     }
 
     return stmt;

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/StmtDeserializer.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/StmtDeserializer.java
@@ -130,7 +130,7 @@ class StmtDeserializer extends JsonDeserializer<Stmt> {
 
     if (file != null && row != null && col != null) {
       // end_row/end_col were added to the IR later, in OPA 1.20.0
-      // (PR open-policy-agent/opa#9007).
+      // (https://github.com/open-policy-agent/opa/pull/9007).
       // In older plans, the 3-arg setLocation collapses the range to a point,
       // degrading coverage to line granularity.
       JsonNode endRow = stmtNode.get("end_row");

--- a/opa-jackson/src/test/java/io/github/open_policy_agent/opa/jackson/OpaCoverageReportTest.java
+++ b/opa-jackson/src/test/java/io/github/open_policy_agent/opa/jackson/OpaCoverageReportTest.java
@@ -4,64 +4,44 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.List;
-import java.util.stream.Stream;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import io.github.open_policy_agent.opa.ir.Location;
 import io.github.open_policy_agent.opa.tracing.CoverageProfiler;
 
 class OpaCoverageReportTest {
 
-  /** A coverage range as it should appear in the OPA JSON output. */
-  private static final class Range {
-    final int start;
-    final int end;
-
-    Range(int start, int end) {
-      this.start = start;
-      this.end = end;
-    }
-  }
-
-  static Stream<Arguments> rangeCases() {
-    return Stream.of(
-        Arguments.of(
-            "single row emits a singleton range",
-            List.of(5),
-            List.of(new Range(5, 5))),
-        Arguments.of(
-            "contiguous rows are coalesced",
-            List.of(5, 6, 7),
-            List.of(new Range(5, 7))),
-        Arguments.of(
-            "disjoint rows emit multiple ranges",
-            List.of(5, 7, 8, 10),
-            List.of(new Range(5, 5), new Range(7, 8), new Range(10, 10))),
-        Arguments.of(
-            "input order does not matter; output is sorted",
-            List.of(10, 5, 7),
-            List.of(new Range(5, 5), new Range(7, 7), new Range(10, 10))));
-  }
-
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("rangeCases")
-  void from_emitsExpectedRangesForSingleFile(
-      String name, List<Integer> rows, List<Range> expected) {
+  @Test
+  void covered_emitsRawRangesWithColumnsSortedNotCoalesced() {
     CoverageProfiler profiler = new CoverageProfiler();
-    rows.forEach(row -> profiler.addEntry(new Location(0, 1, row), 0));
+    profiler.addEntry(new Location(0, 5, 6, 12, 6), 0); // row 6, col 5..12
+    profiler.addEntry(new Location(0, 2, 5, 14, 5), 0); // row 5, col 2..14
 
     ObjectNode report = OpaCoverageReport.from(profiler, List.of("policy.rego"));
 
     JsonNode covered = report.path("files").path("policy.rego").path("covered");
-    assertEquals(expected.size(), covered.size());
-    for (int i = 0; i < expected.size(); i++) {
-      assertEquals(expected.get(i).start, covered.get(i).path("start").path("row").asInt());
-      assertEquals(expected.get(i).end, covered.get(i).path("end").path("row").asInt());
-    }
+    assertEquals(2, covered.size());
+
+    assertEquals(5, covered.get(0).path("start").path("row").asInt());
+    assertEquals(2, covered.get(0).path("start").path("col").asInt());
+    assertEquals(5, covered.get(0).path("end").path("row").asInt());
+    assertEquals(14, covered.get(0).path("end").path("col").asInt());
+
+    assertEquals(6, covered.get(1).path("start").path("row").asInt());
+    assertEquals(5, covered.get(1).path("start").path("col").asInt());
+  }
+
+  @Test
+  void position_omitsColumnWhenZero() {
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(new Location(0, 0, 5, 0, 5), 0); // col 0 both ends
+
+    ObjectNode report = OpaCoverageReport.from(profiler, List.of("policy.rego"));
+
+    JsonNode start = report.path("files").path("policy.rego").path("covered").get(0).path("start");
+    assertEquals(5, start.path("row").asInt());
+    assertFalse(start.has("col"));
   }
 
   @Test
@@ -76,8 +56,8 @@ class OpaCoverageReportTest {
   @Test
   void multipleFiles_eachAppearWithOwnFilename() {
     CoverageProfiler profiler = new CoverageProfiler();
-    profiler.addEntry(new Location(0, 1, 5), 0);
-    profiler.addEntry(new Location(1, 1, 12), 0);
+    profiler.addEntry(new Location(0, 1, 5, 10, 5), 0);
+    profiler.addEntry(new Location(1, 1, 12, 10, 12), 0);
 
     ObjectNode report = OpaCoverageReport.from(profiler, List.of("a.rego", "b.rego"));
 
@@ -90,8 +70,8 @@ class OpaCoverageReportTest {
   @Test
   void unknownFileIndex_isSkipped() {
     CoverageProfiler profiler = new CoverageProfiler();
-    profiler.addEntry(new Location(0, 1, 5), 0);
-    profiler.addEntry(new Location(7, 1, 9), 0); // file index 7 has no filename mapping
+    profiler.addEntry(new Location(0, 1, 5, 10, 5), 0);
+    profiler.addEntry(new Location(7, 1, 9, 10, 9), 0); // file index 7 has no name
 
     ObjectNode report = OpaCoverageReport.from(profiler, List.of("policy.rego"));
 

--- a/opa-proto/src/main/java/io/github/open_policy_agent/opa/proto/PlanMapper.java
+++ b/opa-proto/src/main/java/io/github/open_policy_agent/opa/proto/PlanMapper.java
@@ -272,11 +272,16 @@ final class PlanMapper {
       default -> throw new IllegalArgumentException("unsupported statement kind: " + s.getKindCase());
     }
 
-    // The source-location triple lives on the proto Stmt envelope; the SDK carries it on BaseStmt.
+    // The proto envelope carries the source location. end_col/end_row are 0 for plans built before
+    // https://github.com/open-policy-agent/opa/pull/9007, so fall back to (row, col) there to keep
+    // the range a point rather than inverting it.
     if (out instanceof BaseStmt base) {
-      base.setFile(s.getFile());
-      base.setCol(s.getCol());
-      base.setRow(s.getRow());
+      base.setLocation(
+          s.getFile(),
+          s.getRow(),
+          s.getCol(),
+          s.getEndRow() != 0 ? s.getEndRow() : s.getRow(),
+          s.getEndCol() != 0 ? s.getEndCol() : s.getCol());
     }
     return out;
   }


### PR DESCRIPTION
Follows functionality added in https://github.com/open-policy-agent/opa/pull/9007 to save this data to IR plans.

Example range based coverage from my local tester (`true, true` yes not make it into the plan, something for the likes of https://github.com/open-policy-agent/opa/pull/9031 etc)


<img width="2234" height="1074" alt="Screenshot" src="https://github.com/user-attachments/assets/5ca23f92-0bae-499c-9d35-08e6abc23a8d" />
