### PR TITLE
time: Match go time format for all jvm locales

### DIFF
--- a/opa-builtins/opa-builtins-time/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/TimeBuiltins.java
+++ b/opa-builtins/opa-builtins-time/src/main/java/io/github/open_policy_agent/opa/ast/builtin/impls/TimeBuiltins.java
@@ -89,7 +89,9 @@ public class TimeBuiltins implements BuiltinProvider {
             x = getZonedDateTime(args[0]);
         }
 
-        String formatted = DateTimeFormatter.ofPattern(format).format(x);
+        // Go's layouts use fixed English month/day/AM-PM names regardless of the
+        // JVM's default locale, so pin the formatter locale rather than inheriting it.
+        String formatted = DateTimeFormatter.ofPattern(format, Locale.ENGLISH).format(x);
 
         return new RegoString(formatted);
     }
@@ -380,7 +382,9 @@ public class TimeBuiltins implements BuiltinProvider {
         TemporalAccessor parsed = null;
         for (String pattern : javaPattern) {
             try {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+                // Go's layouts use fixed English month/day/AM-PM names regardless of the
+                // JVM's default locale, so pin the formatter locale rather than inheriting it.
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH);
                 parsed = formatter.parse(value);
                 break;
             } catch (DateTimeParseException ignored) {

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/GoTimeLayoutConverterTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ast/builtin/impls/GoTimeLayoutConverterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
 import io.github.open_policy_agent.opa.ast.builtin.impls.utils.GoTimeLayoutConverter;
 
@@ -538,7 +539,9 @@ public class GoTimeLayoutConverterTest {
     boolean parsed = false;
     for (String pattern : patterns) {
       try {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+        // Go's layouts use fixed English month/day/AM-PM names regardless of the
+        // JVM's default locale, so pin the formatter locale rather than inheriting it.
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH);
         TemporalAccessor result = formatter.parse(value);
         assertNotNull(result);
         parsed = true;


### PR DESCRIPTION
./gradlew test will fail for non en_US otherwise.