### PR TITLE
feat(bundles): add `Accept` header for IR-format bundles

### DIFF
--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/BundleDownloader.java
@@ -62,12 +62,35 @@ public abstract class BundleDownloader {
 
   private static final Set<String> ALLOWED_CONTENT_TYPES =
       Set.of(
+          "application/vnd.openpolicyagent.bundle.ir.v1+gzip",
           "application/vnd.openpolicyagent.bundles",
           "application/gzip",
           "application/x-gzip",
           "application/octet-stream",
           "binary/octet-stream",
           "application/x-tar");
+
+  /**
+   * Default {@code Accept} for bundle requests: the media types this SDK can consume, in preference
+   * order, weighted with q-factors.
+   *
+   * <p>This SDK evaluates the IR ("plan") bundle format, so IR is requested first. The remaining
+   * entries keep the request working against servers that don't negotiate — a plain OPA bundle, any
+   * gzip, and finally a {@code &#42;/&#42;} catch-all for servers that ignore {@code Accept}
+   * entirely and just serve a tarball. Because the weights are only relative, a server that
+   * understands none of the named types can still respond rather than returning {@code 406 Not
+   * Acceptable}.
+   *
+   * <p>Applied <em>before</em> the service config's {@code headers} are merged in, so an operator
+   * can override it per service — see {@link ServicePlugin.Service#applyHeaders}.
+   */
+  static final String DEFAULT_ACCEPT_HEADER =
+      String.join(
+          ", ",
+          "application/vnd.openpolicyagent.bundle.ir.v1+gzip;q=1.0",
+          "application/vnd.openpolicyagent.bundles;q=0.9",
+          "application/gzip;q=0.8",
+          "*/*;q=0.1");
 
   /**
    * Construct a BundleDownloader.
@@ -335,7 +358,7 @@ public abstract class BundleDownloader {
         HttpRequest.newBuilder()
             .uri(uri)
             .timeout(requestTimeout())
-            .header("Accept", "application/vnd.openpolicyagent.bundles")
+            .header("Accept", DEFAULT_ACCEPT_HEADER)
             .GET();
 
     if (etag != null) {
@@ -344,6 +367,7 @@ public abstract class BundleDownloader {
 
     if (authService != null) {
       requestBuilder = authService.applyCredentials(requestBuilder);
+      // Applied last, and with setHeader, so a service-config header wins over the defaults above.
       requestBuilder = authService.applyHeaders(requestBuilder);
     }
 

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/ServicePlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/ServicePlugin.java
@@ -374,7 +374,8 @@ public final class ServicePlugin implements Plugin {
     /**
      * Apply this service's user-supplied {@code headers} to a request. Uses {@code setHeader}
      * (replace, not append) so user-supplied entries override built-in headers like
-     * {@code Authorization} rather than producing duplicates.
+     * {@code Authorization} or the bundle {@code Accept} default rather than producing duplicates.
+     * Header names match case-insensitively, so {@code accept} overrides {@code Accept}.
      */
     public HttpRequest.Builder applyHeaders(HttpRequest.Builder request) {
       if (headers != null) {

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderAcceptHeaderTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/BundleDownloaderAcceptHeaderTest.java
@@ -1,0 +1,206 @@
+package io.github.open_policy_agent.opa.plugins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import io.github.open_policy_agent.opa.config.Config;
+import io.github.open_policy_agent.opa.logging.Logger;
+import io.github.open_policy_agent.opa.storage.InMem;
+
+/**
+ * Tests the {@code Accept} header sent on bundle downloads: the q-weighted IR-first default, and
+ * the operator's ability to override it via a service's {@code headers}.
+ */
+class BundleDownloaderAcceptHeaderTest {
+
+  private HttpServer server;
+  private ServicePlugin servicePlugin;
+
+  /** Request headers seen by the test server, one entry per request, in arrival order. */
+  private final List<Map<String, List<String>>> requests = new CopyOnWriteArrayList<>();
+
+  @AfterEach
+  void tearDown() {
+    if (servicePlugin != null) {
+      servicePlugin.stop();
+    }
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void defaultAcceptHeader_prefersIrWithQWeightedFallbacks() {
+    assertEquals(
+        "application/vnd.openpolicyagent.bundle.ir.v1+gzip;q=1.0, "
+            + "application/vnd.openpolicyagent.bundles;q=0.9, "
+            + "application/gzip;q=0.8, "
+            + "*/*;q=0.1",
+        BundleDownloader.DEFAULT_ACCEPT_HEADER);
+  }
+
+  @Test
+  void download_sendsDefaultAcceptHeader() throws Exception {
+    download(null);
+
+    assertEquals(
+        Collections.singletonList(BundleDownloader.DEFAULT_ACCEPT_HEADER),
+        accept(0),
+        "expected exactly one Accept header carrying the default");
+  }
+
+  @Test
+  void download_serviceHeaderAccept_overridesDefault() throws Exception {
+    download(Collections.singletonMap("Accept", "application/gzip"));
+
+    assertEquals(Collections.singletonList("application/gzip"), accept(0));
+  }
+
+  @Test
+  void download_serviceHeaderLowercaseAccept_overridesDefault() throws Exception {
+    // HTTP header names are case-insensitive, so a lowercase override must replace — not
+    // duplicate — the default.
+    download(Collections.singletonMap("accept", "application/gzip"));
+
+    assertEquals(Collections.singletonList("application/gzip"), accept(0));
+  }
+
+  @Test
+  void download_unrelatedServiceHeader_keepsDefaultAccept() throws Exception {
+    download(Collections.singletonMap("X-Custom", "custom-value"));
+
+    assertEquals(Collections.singletonList(BundleDownloader.DEFAULT_ACCEPT_HEADER), accept(0));
+    assertEquals(
+        Collections.singletonList("custom-value"), requests.get(0).get("X-Custom"));
+  }
+
+  @Test
+  void download_conditionalRequest_sendsAcceptAlongsideIfNoneMatch() throws Exception {
+    // Second poll carries If-None-Match from the first response's ETag; Accept must survive.
+    Downloader downloader = download(null);
+    downloader.downloadBundle().get(10, TimeUnit.SECONDS);
+
+    assertEquals(2, requests.size(), "expected a second, conditional request");
+    assertEquals(Collections.singletonList("\"rev-1\""), requests.get(1).get("If-None-Match"));
+    assertEquals(Collections.singletonList(BundleDownloader.DEFAULT_ACCEPT_HEADER), accept(1));
+  }
+
+  @Test
+  void download_irContentType_isAccepted() throws Exception {
+    // The IR type the default Accept asks for must also be allowed on the way back, or a server
+    // that honors the preference would be rejected as an unexpected Content-Type.
+    Downloader downloader = download(null);
+
+    assertTrue(downloader.activated, "IR-typed bundle response should have been activated");
+  }
+
+  private List<String> accept(int requestIndex) {
+    return requests.get(requestIndex).get("Accept");
+  }
+
+  /**
+   * Runs a single download against a server that answers with an IR-typed bundle and an ETag,
+   * then 304s any conditional follow-up. Returns the downloader so a test can poll again.
+   */
+  private Downloader download(Map<String, String> serviceHeaders) throws Exception {
+    byte[] bundleData = createValidBundle();
+
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.createContext("/bundle.tar.gz", exchange -> {
+      Map<String, List<String>> seen = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+      exchange.getRequestHeaders().forEach((k, v) -> seen.put(k, new ArrayList<>(v)));
+      requests.add(seen);
+
+      if (exchange.getRequestHeaders().containsKey("If-None-Match")) {
+        exchange.sendResponseHeaders(304, -1);
+        exchange.close();
+        return;
+      }
+
+      exchange.getResponseHeaders()
+          .add("Content-Type", "application/vnd.openpolicyagent.bundle.ir.v1+gzip");
+      exchange.getResponseHeaders().add("ETag", "\"rev-1\"");
+      exchange.sendResponseHeaders(200, bundleData.length);
+      exchange.getResponseBody().write(bundleData);
+      exchange.close();
+    });
+    server.start();
+
+    Config.ServiceConfig serviceConfig =
+        new Config.ServiceConfig()
+            .setName("test-service")
+            .setUrl("http://localhost:" + server.getAddress().getPort());
+    serviceConfig.setHeaders(serviceHeaders);
+
+    Config config = new Config();
+    config.setServices(Collections.singletonMap("test-service", serviceConfig));
+
+    PluginManager manager =
+        new PluginManager.Builder()
+            .withId("test")
+            .withStore(new InMem())
+            .withConfig(config)
+            .withLogger(new Logger.StandardLogger())
+            .build();
+
+    servicePlugin = (ServicePlugin) new ServicePlugin().initialize(manager);
+    ServicePlugin.Service svc = servicePlugin.getService("test-service");
+    assertNotNull(svc, "service should have been initialized");
+
+    Downloader downloader = new Downloader(manager, svc);
+    downloader.setService("test-service").setResource("/bundle.tar.gz");
+    downloader.downloadBundle().get(10, TimeUnit.SECONDS);
+
+    return downloader;
+  }
+
+  /** Records that activation happened; the bundle contents are irrelevant to these tests. */
+  private static final class Downloader extends BundleDownloader {
+    private volatile boolean activated;
+
+    Downloader(PluginManager manager, ServicePlugin.Service authService) {
+      super("authz", manager, authService);
+    }
+
+    @Override
+    protected void activateBundle(byte[] bundleData) {
+      this.activated = true;
+    }
+  }
+
+  private static byte[] createValidBundle() throws IOException {
+    ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+    try (GZIPOutputStream gzipOut = new GZIPOutputStream(byteOut);
+        TarArchiveOutputStream tarOut = new TarArchiveOutputStream(gzipOut)) {
+      String planJson =
+          "{\"static\":{\"strings\":[],\"files\":[]},"
+              + "\"plans\":{\"plans\":[{\"name\":\"main/main\",\"blocks\":[]}]},"
+              + "\"funcs\":{\"funcs\":[]}}";
+      byte[] planBytes = planJson.getBytes();
+      TarArchiveEntry plan = new TarArchiveEntry("plan.json");
+      plan.setSize(planBytes.length);
+      tarOut.putArchiveEntry(plan);
+      tarOut.write(planBytes);
+      tarOut.closeArchiveEntry();
+      tarOut.finish();
+    }
+    return byteOut.toByteArray();
+  }
+}


### PR DESCRIPTION
Ports [swift-opa-sdk#46](https://github.com/open-policy-agent/swift-opa-sdk/commit/c9c85c1396457efd60a5a7a2ceb86b0f2e69c543) to Java: bundle requests now send a q-weighted `Accept` header preferring the Rego IR format, with lower-weighted fallbacks so servers that don't negotiate keep working. This SDK only evaluates IR bundles, so it was previously asking a content-negotiating bundle server for precisely the format it cannot use.

The IR media type is also added to `ALLOWED_CONTENT_TYPES` — Java hard-fails on an unrecognized response `Content-Type`, so the `Accept` change alone would break against a server that *honors* the new preference. Operators can still override `Accept` per service via `services.<name>.headers`.
