### PR TITLE
coverage: Add support for unplanned_rules 

### DIFF
--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/policy/Policy.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/policy/Policy.java
@@ -1,5 +1,6 @@
 package io.github.open_policy_agent.opa.ir.policy;
 
+import java.util.List;
 import java.util.Objects;
 
 /** Represents a planned policy query. */
@@ -12,17 +13,33 @@ public class Policy {
 
   private Funcs funcs;
 
-  public Policy(Static staticField, Plans plans, Funcs funcs) {
+  private List<UnplannedRule> unplannedRules;
+
+  public Policy(Static staticField, Plans plans, Funcs funcs, List<UnplannedRule> unplannedRules) {
     this.staticField = staticField;
     this.plans = plans;
     this.funcs = funcs;
+    this.unplannedRules = unplannedRules;
+  }
+
+  public Policy(Static staticField, Plans plans, Funcs funcs) {
+    this(staticField, plans, funcs, null);
   }
 
   public Policy() {}
 
   @Override
   public String toString() {
-    return "Policy{" + "staticField=" + staticField + ", plans=" + plans + ", funcs=" + funcs + '}';
+    return "Policy{"
+        + "staticField="
+        + staticField
+        + ", plans="
+        + plans
+        + ", funcs="
+        + funcs
+        + ", unplannedRules="
+        + unplannedRules
+        + '}';
   }
 
   public Static getStatic() {
@@ -49,6 +66,14 @@ public class Policy {
     this.funcs = funcs;
   }
 
+  public List<UnplannedRule> getUnplannedRules() {
+    return unplannedRules;
+  }
+
+  public void setUnplannedRules(List<UnplannedRule> unplannedRules) {
+    this.unplannedRules = unplannedRules;
+  }
+
   @Override
   public boolean equals(Object o) {
       if (this == o) {
@@ -66,7 +91,10 @@ public class Policy {
       if (!Objects.equals(plans, policy.plans)) {
           return false;
       }
-    return Objects.equals(funcs, policy.funcs);
+      if (!Objects.equals(funcs, policy.funcs)) {
+          return false;
+      }
+    return Objects.equals(unplannedRules, policy.unplannedRules);
   }
 
   @Override
@@ -74,6 +102,7 @@ public class Policy {
     int result = staticField != null ? staticField.hashCode() : 0;
     result = 31 * result + (plans != null ? plans.hashCode() : 0);
     result = 31 * result + (funcs != null ? funcs.hashCode() : 0);
+    result = 31 * result + (unplannedRules != null ? unplannedRules.hashCode() : 0);
     return result;
   }
 }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/policy/UnplannedRule.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/policy/UnplannedRule.java
@@ -1,0 +1,62 @@
+package io.github.open_policy_agent.opa.ir.policy;
+
+import io.github.open_policy_agent.opa.ir.Location;
+import java.util.Objects;
+
+/**
+ * A rule not reachable from the build-time entrypoint, so the planner never compiled it. Included
+ * so that, when tracing is enabled, evaluators can report coverage data for rules the plan never
+ * touches.
+ */
+public class UnplannedRule {
+  private String path;
+
+  private Location location;
+
+  public UnplannedRule() {}
+
+  public UnplannedRule(String path, Location location) {
+    this.path = path;
+    this.location = location;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public Location getLocation() {
+    return location;
+  }
+
+  public void setLocation(Location location) {
+    this.location = location;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    UnplannedRule that = (UnplannedRule) o;
+
+    if (!Objects.equals(path, that.path)) {
+      return false;
+    }
+    return Objects.equals(location, that.location);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = path != null ? path.hashCode() : 0;
+    result = 31 * result + (location != null ? location.hashCode() : 0);
+    return result;
+  }
+}

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/PolicyTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/ir/PolicyTest.java
@@ -19,6 +19,7 @@ import io.github.open_policy_agent.opa.ir.policy.Plans;
 import io.github.open_policy_agent.opa.ir.policy.Policy;
 import io.github.open_policy_agent.opa.ir.policy.Static;
 import io.github.open_policy_agent.opa.ir.policy.StringConst;
+import io.github.open_policy_agent.opa.ir.policy.UnplannedRule;
 import io.github.open_policy_agent.opa.ir.policy.types.AnyType;
 import io.github.open_policy_agent.opa.ir.policy.types.ArrayType;
 import io.github.open_policy_agent.opa.ir.policy.types.BooleanType;
@@ -1135,5 +1136,24 @@ class PolicyTest {
     assertNull(policy.getFuncs());
     assertNull(policy.getStatic());
     assertNull(policy.getPlans());
+  }
+
+  @Test
+  public void testPolicyDeserialization_unplannedRules() throws IOException {
+    File jsonFile =
+        new File(
+            Objects.requireNonNull(
+                    getClass()
+                        .getClassLoader()
+                        .getResource("ir/testdata/policy-with-unplanned-rules.json"))
+                .getFile());
+
+    Policy policy = policyReader.read(Files.newInputStream(jsonFile.toPath()));
+    assertNotNull(policy, "Policy should not be null");
+    assertEquals(1, policy.getUnplannedRules().size());
+
+    UnplannedRule unplannedRule = policy.getUnplannedRules().get(0);
+    assertEquals("data.example.unused", unplannedRule.getPath());
+    assertEquals(new Location(0, 1, 11, 15, 11), unplannedRule.getLocation());
   }
 }

--- a/opa-evaluator/src/test/resources/ir/testdata/policy-with-unplanned-rules.json
+++ b/opa-evaluator/src/test/resources/ir/testdata/policy-with-unplanned-rules.json
@@ -1,0 +1,8 @@
+{
+  "unplanned_rules": [
+    {
+      "path": "data.example.unused",
+      "location": {"file": 0, "col": 1, "row": 11, "end_col": 15, "end_row": 11}
+    }
+  ]
+}

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/IrModule.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/IrModule.java
@@ -1,5 +1,6 @@
 package io.github.open_policy_agent.opa.jackson;
 
+import io.github.open_policy_agent.opa.ir.Location;
 import io.github.open_policy_agent.opa.ir.Operand;
 import io.github.open_policy_agent.opa.ir.policy.types.Type;
 import io.github.open_policy_agent.opa.ir.stmts.Stmt;
@@ -19,6 +20,7 @@ public class IrModule extends SimpleModule {
 
   public IrModule() {
     super("opa-ir");
+    addDeserializer(Location.class, new LocationDeserializer());
     addDeserializer(Operand.class, new OperandDeserializer());
     addDeserializer(Stmt.class, new StmtDeserializer());
     addDeserializer(Type.class, new TypeDeserializer());

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/LocationDeserializer.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/LocationDeserializer.java
@@ -1,0 +1,28 @@
+package io.github.open_policy_agent.opa.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.open_policy_agent.opa.ir.Location;
+import java.io.IOException;
+
+/**
+ * Deserializes a standalone {@code Location} JSON object ({@code file/col/row/end_col/end_row}),
+ * e.g. {@code UnplannedRule.location}. Until now, every JSON occurrence of these fields was
+ * flattened onto a statement envelope and handled by {@link StmtDeserializer}; {@code
+ * UnplannedRule} is the first place a {@code Location} appears as its own nested object, hence
+ * this dedicated deserializer.
+ */
+class LocationDeserializer extends JsonDeserializer<Location> {
+  @Override
+  public Location deserialize(JsonParser jp, DeserializationContext ctx) throws IOException {
+    JsonNode node = jp.getCodec().readTree(jp);
+    return new Location(
+        node.path("file").asInt(),
+        node.path("col").asInt(),
+        node.path("row").asInt(),
+        node.path("end_col").asInt(),
+        node.path("end_row").asInt());
+  }
+}

--- a/opa-proto/src/main/java/io/github/open_policy_agent/opa/proto/PlanMapper.java
+++ b/opa-proto/src/main/java/io/github/open_policy_agent/opa/proto/PlanMapper.java
@@ -1,5 +1,6 @@
 package io.github.open_policy_agent.opa.proto;
 
+import io.github.open_policy_agent.opa.ir.Location;
 import io.github.open_policy_agent.opa.ir.Operand;
 import io.github.open_policy_agent.opa.ir.policy.Block;
 import io.github.open_policy_agent.opa.ir.policy.BuiltinFunc;
@@ -10,6 +11,7 @@ import io.github.open_policy_agent.opa.ir.policy.Plans;
 import io.github.open_policy_agent.opa.ir.policy.Policy;
 import io.github.open_policy_agent.opa.ir.policy.Static;
 import io.github.open_policy_agent.opa.ir.policy.StringConst;
+import io.github.open_policy_agent.opa.ir.policy.UnplannedRule;
 import io.github.open_policy_agent.opa.ir.stmts.ArrayAppendStmt;
 import io.github.open_policy_agent.opa.ir.stmts.AssignIntStmt;
 import io.github.open_policy_agent.opa.ir.stmts.AssignVarOnceStmt;
@@ -60,8 +62,8 @@ import java.util.List;
  *
  * <p>The proto types (generated under {@code opa.ir.v1}) collide by simple name with several SDK
  * model types ({@code Policy}, {@code Static}, {@code Block}, {@code Stmt}, {@code Operand}, {@code
- * Val}). To keep the SDK types imported and readable, proto payloads are bound with {@code var}
- * rather than named explicitly.
+ * Val}, {@code Location}). To keep the SDK types imported and readable, proto payloads are bound
+ * with {@code var} rather than named explicitly.
  */
 final class PlanMapper {
 
@@ -71,7 +73,17 @@ final class PlanMapper {
     Static staticField = toStatic(proto.getStatic());
     Plans plans = toPlans(proto.getPlans());
     Funcs funcs = toFuncs(proto.getFuncs());
-    return new Policy(staticField, plans, funcs);
+
+    List<UnplannedRule> unplannedRules = new ArrayList<>(proto.getUnplannedRulesCount());
+    for (var r : proto.getUnplannedRulesList()) {
+      var loc = r.getLocation();
+      unplannedRules.add(
+          new UnplannedRule(
+              r.getPath(),
+              new Location(loc.getFile(), loc.getCol(), loc.getRow(), loc.getEndCol(), loc.getEndRow())));
+    }
+
+    return new Policy(staticField, plans, funcs, unplannedRules);
   }
 
   private static Static toStatic(opa.ir.v1.Static proto) {

--- a/opa-proto/src/test/java/io/github/open_policy_agent/opa/proto/ProtoUnplannedRulesTest.java
+++ b/opa-proto/src/test/java/io/github/open_policy_agent/opa/proto/ProtoUnplannedRulesTest.java
@@ -1,0 +1,38 @@
+package io.github.open_policy_agent.opa.proto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.open_policy_agent.opa.ir.Location;
+import io.github.open_policy_agent.opa.ir.policy.Policy;
+import io.github.open_policy_agent.opa.ir.policy.UnplannedRule;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import opa.ir.v1.Plans;
+import org.junit.jupiter.api.Test;
+
+/** Verifies {@code unplanned_rules} decode into the SDK's {@link Policy} model. */
+class ProtoUnplannedRulesTest {
+
+  @Test
+  void unplannedRulesDecodeIntoSdkModel() throws IOException {
+    opa.ir.v1.Policy proto =
+        opa.ir.v1.Policy.newBuilder()
+            .setPlans(Plans.newBuilder().build())
+            .addUnplannedRules(
+                opa.ir.v1.UnplannedRule.newBuilder()
+                    .setPath("data.example.unused")
+                    .setLocation(
+                        opa.ir.v1.Location.newBuilder()
+                            .setFile(0)
+                            .setCol(1)
+                            .setRow(11)
+                            .setEndCol(15)
+                            .setEndRow(11)))
+            .build();
+
+    Policy policy = new ProtoBundleReader().decodePlan(new ByteArrayInputStream(proto.toByteArray()));
+
+    assertThat(policy.getUnplannedRules())
+        .containsExactly(new UnplannedRule("data.example.unused", new Location(0, 1, 11, 15, 11)));
+  }
+}


### PR DESCRIPTION
After https://github.com/open-policy-agent/java-opa-sdk/pull/208


This gives the SDK the capability to load and expose the unplanned_rules
data in the plan if present.