### PR TITLE
Add CoverageRecorder to save coverage reports

### DIFF
--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/policy/Policy.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/ir/policy/Policy.java
@@ -1,5 +1,6 @@
 package io.github.open_policy_agent.opa.ir.policy;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -44,6 +45,26 @@ public class Policy {
 
   public Static getStatic() {
     return staticField;
+  }
+
+  /**
+   * The plan's file table: index -&gt; filename, in the order the planner assigned indices.
+   *
+   * <p>Coverage data identifies source locations by file index, so consumers need this to resolve
+   * an index back to a path. Indices are plan-local, so a table from one policy must never be used
+   * to resolve another's.
+   *
+   * @return filenames by plan file index
+   */
+  public List<String> getStaticFilenames() {
+    if (staticField == null || staticField.getFiles() == null) {
+      return List.of();
+    }
+    List<String> filenames = new ArrayList<>(staticField.getFiles().size());
+    for (StringConst file : staticField.getFiles()) {
+      filenames.add(file == null ? null : file.getValue());
+    }
+    return filenames;
   }
 
   public void setStatic(Static staticField) {

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/rego/EvaluationContext.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/rego/EvaluationContext.java
@@ -11,18 +11,22 @@ import io.github.open_policy_agent.opa.ast.types.RegoValue;
 import io.github.open_policy_agent.opa.cache.NdBuiltinCache;
 import io.github.open_policy_agent.opa.ir.BlockEvent;
 import io.github.open_policy_agent.opa.ir.StatementEvent;
+import io.github.open_policy_agent.opa.ir.policy.Policy;
 import io.github.open_policy_agent.opa.ir.stmts.Stmt;
 import io.github.open_policy_agent.opa.metrics.Metrics;
 import io.github.open_policy_agent.opa.metrics.NoOpMetrics;
 import io.github.open_policy_agent.opa.profiling.NoOpStatementProfiler;
 import io.github.open_policy_agent.opa.profiling.StatementProfiler;
 import io.github.open_policy_agent.opa.storage.Store;
+import io.github.open_policy_agent.opa.tracing.CoverageRecorder;
 import io.github.open_policy_agent.opa.tracing.Event;
 import io.github.open_policy_agent.opa.tracing.Operation;
 import io.github.open_policy_agent.opa.tracing.Profiler;
 import io.github.open_policy_agent.opa.tracing.QueryTracer;
 
 public class EvaluationContext {
+  private static final Logger LOGGER = new Logger.StandardLogger();
+
   public String entrypoint;
   public RegoValue input;
   public Store store;
@@ -300,7 +304,50 @@ public class EvaluationContext {
       if (statementProfiler == null) {
         statementProfiler = new NoOpStatementProfiler();
       }
+      installCoverageProfiler();
       return new EvaluationContext(this);
+    }
+
+    /**
+     * Adds the JVM-wide coverage profiler when {@code -Dopa.coverage.output} is set.
+     *
+     * <p>Every evaluation passes through here. This is what lets coverage be collected from code
+     * that never asked for it. Profilers are keyed by policy, so repeated evaluations in one JVM
+     * accumulate into the same profiler.
+     */
+    private void installCoverageProfiler() {
+      if (!CoverageRecorder.isEnabled() || store == null) {
+        return;
+      }
+
+      try {
+        // filter guards against re-adding the shared profiler if this builder is reused to
+        // build() more than once, which would deliver every callback to it repeatedly.
+        CoverageRecorder.profilerFor(policyForCoverage())
+            .filter(profiler -> !this.profilers.contains(profiler))
+            .ifPresent(this.profilers::add);
+      } catch (RuntimeException e) {
+        LOGGER.error("could not resolve policy for coverage: %s", e);
+      }
+    }
+
+    /**
+     * The policy for {@link #entrypoint}, or {@code null} when it does not resolve.
+     *
+     * <p>{@link Store#getIrPolicyForEntrypoint(String)} falls back to the first policy it finds
+     * when no plan matches, so the plan itself is checked to tell "no policy for this entrypoint"
+     * apart from "some other policy" — feeding coverage from the wrong policy back into a
+     * profiler would resolve its ranges against the wrong file table.
+     */
+    private Policy policyForCoverage() {
+      Policy policy = store.getIrPolicyForEntrypoint(entrypoint);
+      if (policy == null
+          || policy.getPlans() == null
+          || policy.getPlans().getPlans() == null
+          || policy.getPlans().getPlanByName(entrypoint) == null) {
+        return null;
+      }
+      return policy;
     }
   }
 }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageProfiler.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageProfiler.java
@@ -2,10 +2,10 @@ package io.github.open_policy_agent.opa.tracing;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import io.github.open_policy_agent.opa.ir.Location;
 
 /**
@@ -21,10 +21,14 @@ import io.github.open_policy_agent.opa.ir.Location;
  * one which exited the block. Those ranges are reported as not-covered, which
  * matches the expected coverage semantics.
  *
+ * <p>Thread-safe: a single instance may be shared across concurrent evaluations (see {@link
+ * CoverageRecorder}). Mutation goes through concurrent collections and the accessors return
+ * snapshots, so readers never see a partially-updated map or race a concurrent {@code addEntry}.
+ *
  * <p>If only location tracing is required, this is a more performant alternative to {@link DurationProfiler}
  */
 public class CoverageProfiler implements Profiler {
-  private final Map<Integer, Set<Range>> hitsByFile = new HashMap<>();
+  private final Map<Integer, Set<Range>> hitsByFile = new ConcurrentHashMap<>();
 
   @Override
   public void addStart() {
@@ -33,23 +37,31 @@ public class CoverageProfiler implements Profiler {
 
   @Override
   public void addEntry(Location location, long duration) {
-      if (location == null) {
-          return;
-      }
-    hitsByFile.computeIfAbsent(location.getFile(), k -> new HashSet<>()).add(Range.of(location));
+    if (location == null) {
+      return;
+    }
+    hitsByFile
+        .computeIfAbsent(location.getFile(), k -> ConcurrentHashMap.newKeySet())
+        .add(Range.of(location));
   }
 
   /**
    * @return per-file map of executed source ranges. Outer key is the file index in the policy's
-   *     static file table; inner value is the set of source ranges that were executed.
+   *     static file table; inner value is the set of source ranges that were executed. The returned
+   *     map is a snapshot; later {@code addEntry} calls are not reflected in it.
    */
   public Map<Integer, Set<Range>> getCoveredRanges() {
-    return Collections.unmodifiableMap(hitsByFile);
+    Map<Integer, Set<Range>> snapshot = new HashMap<>();
+    for (Map.Entry<Integer, Set<Range>> entry : hitsByFile.entrySet()) {
+      snapshot.put(entry.getKey(), Set.copyOf(entry.getValue()));
+    }
+    return Collections.unmodifiableMap(snapshot);
   }
 
   /**
    * @return map of executed source rows (per file), derived from the recorded ranges, for any
-   *     line-based consumers. Use {@link #getCoveredRanges()} for column-precise coverage.
+   *     line-based consumers. Use {@link #getCoveredRanges()} for column-precise coverage. The
+   *     returned map is a snapshot; later {@code addEntry} calls are not reflected in it.
    */
   public Map<Integer, Set<Integer>> getCoveredLines() {
     Map<Integer, Set<Integer>> rowsByFile = new HashMap<>();

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageRecorder.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageRecorder.java
@@ -1,0 +1,155 @@
+package io.github.open_policy_agent.opa.tracing;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import io.github.open_policy_agent.opa.ir.policy.Policy;
+import io.github.open_policy_agent.opa.logging.Logger;
+import io.github.open_policy_agent.opa.spi.Services;
+
+/**
+ * Records Rego coverage reports for the running JVM and writes them out once completed.
+ *
+ * <p>Off unless {@code -Dopa.coverage.output=<dir>} is set. Callers that do not ask for coverage
+ * see no behaviour change. When on, {@link
+ * io.github.open_policy_agent.opa.rego.EvaluationContext.Builder#build()} installs a profiler on
+ * every evaluation, which lets an unmodified test suite be measured without a JVM agent or
+ * changes to the code being tested.
+ *
+ * <p>One profiler per {@link Policy}, keyed by identity: coverage locations are file
+ * indices into that plan's own static table, so a single shared profiler would resolve one
+ * policy's indices against another policy's files. Each policy has its own report.
+ *
+ * <p>A policy's profiler is shared across every evaluation of that policy, which may run
+ * concurrently, so {@link CoverageProfiler} is itself thread-safe.
+ *
+ * <p>Reports are written by a {@link CoverageReportWriter} found via {@link Services#loadAtMostOne},
+ * the same single-provider policy the SDK's other SPIs use. Without a JSON library on the
+ * classpath, recording stays off rather than failing at exit.
+ */
+public final class CoverageRecorder {
+
+  /**
+   * System property for the directory to write reports to (absent means disabled)
+   */
+  public static final String OUTPUT_DIR_PROPERTY = "opa.coverage.output";
+
+  private static final Logger LOGGER = new Logger.StandardLogger();
+  private static final Object LOCK = new Object();
+
+  private static volatile CoverageRecorder instance;
+  private static volatile boolean initialised;
+
+  private final Path outputDir;
+  private final CoverageReportWriter writer;
+  private final String runId;
+  private final Map<Policy, CoverageProfiler> profilers = new IdentityHashMap<>();
+
+  private CoverageRecorder(Path outputDir, CoverageReportWriter writer) {
+    this.outputDir = outputDir;
+    this.writer = writer;
+    // A random id keeps concurrent and successive JVMs from colliding in a shared output directory.
+    this.runId = UUID.randomUUID().toString();
+  }
+
+  /**
+   * The profiler to record {@code policy}'s coverage. This is created on first use.
+   *
+   * @param policy the policy being evaluated
+   * @return the profiler, empty when coverage recording is off or {@code policy} is null
+   */
+  public static Optional<Profiler> profilerFor(Policy policy) {
+    if (policy == null) {
+      return Optional.empty();
+    }
+    CoverageRecorder recorder = instance();
+    if (recorder == null) {
+      return Optional.empty();
+    }
+    synchronized (LOCK) {
+      return Optional.of(
+          recorder.profilers.computeIfAbsent(policy, p -> new CoverageProfiler()));
+    }
+  }
+
+  /**
+   * True when {@link #OUTPUT_DIR_PROPERTY} is set and a writer was found.
+   */
+  public static boolean isEnabled() {
+    return instance() != null;
+  }
+
+  private static CoverageRecorder instance() {
+    if (initialised) {
+      return instance;
+    }
+    // evaluations can run concurrently, but setup must happen exactly once.
+    synchronized (LOCK) {
+      if (initialised) {
+        return instance;
+      }
+      initialised = true;
+      instance = create();
+      if (instance != null) {
+        CoverageRecorder started = instance;
+        Runtime.getRuntime()
+            .addShutdownHook(new Thread(started::writeReports, "opa-coverage-shutdown"));
+      }
+      return instance;
+    }
+  }
+
+  private static CoverageRecorder create() {
+    String configured = System.getProperty(OUTPUT_DIR_PROPERTY);
+    if (configured == null || configured.isBlank()) {
+      return null;
+    }
+
+    CoverageReportWriter writer =
+        Services.loadAtMostOne(CoverageReportWriter.class).orElse(null);
+    if (writer == null) {
+      LOGGER.error(
+          "%s is set but no CoverageReportWriter is on the classpath; add opa-jackson to record"
+              + " coverage. Continuing without it.",
+          OUTPUT_DIR_PROPERTY);
+      return null;
+    }
+
+    Path dir = Path.of(configured.trim());
+    try {
+      Files.createDirectories(dir);
+    } catch (IOException e) {
+      LOGGER.error("cannot create coverage output directory %s; continuing without: %s", dir, e);
+      return null;
+    }
+    return new CoverageRecorder(dir, writer);
+  }
+
+  private void writeReports() {
+    List<Map.Entry<Policy, CoverageProfiler>> snapshot;
+    synchronized (LOCK) {
+      snapshot = new ArrayList<>(profilers.entrySet());
+    }
+    int index = 0;
+    for (Map.Entry<Policy, CoverageProfiler> entry : snapshot) {
+      // Index disambiguates policies within this JVM; runId disambiguates JVMs.
+      String baseName = "report-" + runId + "-" + index++;
+      try {
+        Policy policy = entry.getKey();
+        CoverageReport report =
+            CoverageReport.from(
+                entry.getValue(), policy.getStaticFilenames(), policy.getUnplannedRules());
+        writer.write(report, outputDir, baseName);
+      } catch (Exception e) {
+        // A shutdown hook cannot usefully propagate error. One bad report does not impact others.
+        LOGGER.error("failed to write coverage report %s: %s", baseName, e);
+      }
+    }
+  }
+}

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageReport.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageReport.java
@@ -1,0 +1,133 @@
+package io.github.open_policy_agent.opa.tracing;
+
+import io.github.open_policy_agent.opa.ir.policy.UnplannedRule;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * The computed coverage result for one policy: which source ranges executed, which did not, the
+ * distinct-line counts, and the coverage percentage. Mirrors the shape of OPA's {@code opa eval
+ * --coverage} output.
+ *
+ * <p>This holds the coverage figures themselves, computed once from a {@link CoverageProfiler}. A
+ * {@link CoverageReportWriter} turns the model into JSON.
+ *
+ * <p>Each executed statement range is reported individually, sorted by position and not coalesced,
+ * matching OPA. {@code covered}/{@code notCovered} may be empty and the line counts count distinct
+ * source rows. File indices outside {@code filenames} are skipped (synthetic statements with no
+ * source mapping). {@code notCovered} ranges come from the plan's {@code unplanned_rules}: rules
+ * the planner never compiled into statements, so they can never be covered.
+ */
+public record CoverageReport(
+    Map<String, FileCoverage> files, int coveredLines, int notCoveredLines, double coverage) {
+
+  /**
+   * Per-file coverage. {@code covered} and {@code notCovered} are sorted by position and may be
+   * empty; {@code coveredLines}/{@code notCoveredLines} count distinct source rows.
+   */
+  public record FileCoverage(
+      List<Range> covered,
+      List<Range> notCovered,
+      int coveredLines,
+      int notCoveredLines,
+      double coverage) {}
+
+  /**
+   * Build the report from recorded coverage.
+   *
+   * @param profiler the profiler that recorded coverage during evaluation
+   * @param filenames file index to filename mapping, typically {@code policy.getStaticFilenames()}
+   * @param unplannedRules rules to report as not covered, typically {@code
+   *     policy.getUnplannedRules()}; may be null
+   * @return the computed, library-neutral report
+   */
+  public static CoverageReport from(
+      CoverageProfiler profiler, List<String> filenames, List<UnplannedRule> unplannedRules) {
+    Map<Integer, Set<Range>> coveredByFile = profiler.getCoveredRanges();
+    Map<Integer, List<Range>> notCoveredByFile = notCoveredRangesByFile(unplannedRules);
+
+    Set<Integer> fileIndices = new TreeSet<>(coveredByFile.keySet());
+    fileIndices.addAll(notCoveredByFile.keySet());
+
+    Map<String, FileCoverage> files = new LinkedHashMap<>();
+    int totalCovered = 0;
+    int totalNotCovered = 0;
+    for (int fileIndex : fileIndices) {
+      if (fileIndex < 0 || fileIndex >= filenames.size()) {
+        continue;
+      }
+
+      Set<Range> covered = coveredByFile.get(fileIndex);
+      List<Range> notCovered = notCoveredByFile.get(fileIndex);
+      boolean hasCovered = covered != null && !covered.isEmpty();
+      boolean hasNotCovered = notCovered != null && !notCovered.isEmpty();
+      if (!hasCovered && !hasNotCovered) {
+        continue;
+      }
+
+      int coveredLines = countLines(covered);
+      int notCoveredLines = countLines(notCovered);
+      files.put(
+          filenames.get(fileIndex),
+          new FileCoverage(
+              sorted(covered),
+              sorted(notCovered),
+              coveredLines,
+              notCoveredLines,
+              coveragePercent(coveredLines, notCoveredLines)));
+      totalCovered += coveredLines;
+      totalNotCovered += notCoveredLines;
+    }
+
+    return new CoverageReport(
+        files, totalCovered, totalNotCovered, coveragePercent(totalCovered, totalNotCovered));
+  }
+
+  /** Distinct source rows spanned by {@code ranges}, matching OPA's line-based counts. */
+  private static int countLines(Collection<Range> ranges) {
+    if (ranges == null || ranges.isEmpty()) {
+      return 0;
+    }
+    Set<Integer> rows = new TreeSet<>();
+    for (Range range : ranges) {
+      for (int row = range.start().getRow(); row <= range.end().getRow(); row++) {
+        rows.add(row);
+      }
+    }
+    return rows.size();
+  }
+
+  private static List<Range> sorted(Collection<Range> ranges) {
+    if (ranges == null || ranges.isEmpty()) {
+      return List.of();
+    }
+    List<Range> result = new ArrayList<>(ranges);
+    result.sort(Range::compareTo);
+    return result;
+  }
+
+  private static double coveragePercent(int coveredLines, int notCoveredLines) {
+    int total = coveredLines + notCoveredLines;
+    return total == 0 ? 0.0 : (double) coveredLines / total * 100;
+  }
+
+  private static Map<Integer, List<Range>> notCoveredRangesByFile(
+      List<UnplannedRule> unplannedRules) {
+    Map<Integer, List<Range>> byFile = new HashMap<>();
+    if (unplannedRules == null) {
+      return byFile;
+    }
+    for (UnplannedRule rule : unplannedRules) {
+      byFile
+          .computeIfAbsent(rule.getLocation().getFile(), k -> new ArrayList<>())
+          .add(Range.of(rule.getLocation()));
+    }
+    return byFile;
+  }
+}

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageReportWriter.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageReportWriter.java
@@ -1,0 +1,25 @@
+package io.github.open_policy_agent.opa.tracing;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Serializes a computed {@link CoverageReport} to disk. Discovered by {@link CoverageRecorder} via
+ * {@link java.util.ServiceLoader}; implementations live in the serialization modules, e.g.
+ * {@code opa-jackson}.
+ *
+ * <p>All coverage semantics are computed upstream in {@link CoverageReport}; an implementation only
+ * encodes that model in its JSON library and writes the bytes out.
+ */
+public interface CoverageReportWriter {
+
+  /**
+   * Write a single report to a distinct path under {@code outputDir}.
+   *
+   * @param report the computed, library-neutral coverage report
+   * @param outputDir directory to write into; already created
+   * @param baseName filename stem unique to this JVM and policy, without extension
+   * @throws IOException if the report cannot be written
+   */
+  void write(CoverageReport report, Path outputDir, String baseName) throws IOException;
+}

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/tracing/CoverageReportTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/tracing/CoverageReportTest.java
@@ -1,0 +1,101 @@
+package io.github.open_policy_agent.opa.tracing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.open_policy_agent.opa.ir.Location;
+import io.github.open_policy_agent.opa.ir.policy.UnplannedRule;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CoverageReportTest {
+
+  @Test
+  void from_recordsCoveredRangesSortedPerFile() {
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(new Location(0, 5, 6, 12, 6), 0); // row 6
+    profiler.addEntry(new Location(0, 2, 5, 14, 5), 0); // row 5
+
+    CoverageReport report = CoverageReport.from(profiler, List.of("policy.rego"), List.of());
+
+    CoverageReport.FileCoverage file = report.files().get("policy.rego");
+    assertEquals(2, file.covered().size());
+    // Sorted by position: row 5 before row 6.
+    assertEquals(5, file.covered().get(0).start().getRow());
+    assertEquals(6, file.covered().get(1).start().getRow());
+    assertTrue(file.notCovered().isEmpty());
+  }
+
+  @Test
+  void from_addsUnplannedRulesAsNotCovered() {
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(new Location(0, 1, 5, 10, 5), 0);
+    List<UnplannedRule> unplannedRules =
+        List.of(new UnplannedRule("data.example.unused", new Location(0, 1, 11, 15, 11)));
+
+    CoverageReport report =
+        CoverageReport.from(profiler, List.of("policy.rego"), unplannedRules);
+
+    CoverageReport.FileCoverage file = report.files().get("policy.rego");
+    assertEquals(1, file.covered().size());
+    assertEquals(1, file.notCovered().size());
+    assertEquals(11, file.notCovered().get(0).start().getRow());
+  }
+
+  @Test
+  void from_countsDistinctLinesAndCoveragePerFileAndOverall() {
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(new Location(0, 1, 5, 10, 5), 0); // covered row 5
+    List<UnplannedRule> unplannedRules =
+        // not covered rows 11..12 (a two-line rule body)
+        List.of(new UnplannedRule("data.example.unused", new Location(0, 1, 11, 15, 12)));
+
+    CoverageReport report =
+        CoverageReport.from(profiler, List.of("policy.rego"), unplannedRules);
+
+    CoverageReport.FileCoverage file = report.files().get("policy.rego");
+    assertEquals(1, file.coveredLines());
+    assertEquals(2, file.notCoveredLines());
+    assertEquals(1.0 / 3 * 100, file.coverage());
+
+    assertEquals(1, report.coveredLines());
+    assertEquals(2, report.notCoveredLines());
+    assertEquals(1.0 / 3 * 100, report.coverage());
+  }
+
+  @Test
+  void from_skipsFileIndicesOutsideFilenameList() {
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(new Location(0, 1, 5, 10, 5), 0);
+    profiler.addEntry(new Location(7, 1, 5, 10, 5), 0); // index 7 has no filename
+
+    CoverageReport report = CoverageReport.from(profiler, List.of("policy.rego"), List.of());
+
+    assertEquals(1, report.files().size());
+    assertTrue(report.files().containsKey("policy.rego"));
+  }
+
+  @Test
+  void from_toleratesNullUnplannedRules() {
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(new Location(0, 1, 5, 10, 5), 0);
+
+    CoverageReport report = CoverageReport.from(profiler, List.of("policy.rego"), null);
+
+    CoverageReport.FileCoverage file = report.files().get("policy.rego");
+    assertFalse(file.covered().isEmpty());
+    assertTrue(file.notCovered().isEmpty());
+  }
+
+  @Test
+  void from_coverageIsZeroWhenNothingRecorded() {
+    CoverageReport report =
+        CoverageReport.from(new CoverageProfiler(), List.of("policy.rego"), List.of());
+
+    assertTrue(report.files().isEmpty());
+    assertEquals(0, report.coveredLines());
+    assertEquals(0, report.notCoveredLines());
+    assertEquals(0.0, report.coverage());
+  }
+}

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/JacksonCoverageReportWriter.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/JacksonCoverageReportWriter.java
@@ -1,0 +1,44 @@
+package io.github.open_policy_agent.opa.jackson;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.open_policy_agent.opa.tracing.CoverageReport;
+import io.github.open_policy_agent.opa.tracing.CoverageReportWriter;
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * The {@code opa-jackson} implementation of {@link CoverageReportWriter}, encoding a {@link
+ * CoverageReport} as {@link OpaCoverageReport} JSON and writing it out. It lives here rather than
+ * beside the interface because {@code opa-evaluator} has no Jackson dependency;
+ * {@code META-INF/services} lets {@code CoverageRecorder} discover it at runtime if present.
+ */
+public final class JacksonCoverageReportWriter implements CoverageReportWriter {
+
+  @Override
+  public void write(CoverageReport report, Path outputDir, String baseName) throws IOException {
+    ObjectNode json = OpaCoverageReport.toJson(report);
+
+    // Write beside the target and move into place to avoid readers getting broken JSON.
+    Path target = outputDir.resolve(baseName + ".json");
+    Path tmp = outputDir.resolve(baseName + ".json.tmp");
+    try {
+      Files.writeString(tmp, json.toString());
+      try {
+        Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE);
+      } catch (AtomicMoveNotSupportedException e) {
+        Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } catch (IOException e) {
+      // Invisible to the glob, so it would linger unnoticed until something else cleaned up.
+      try {
+        Files.deleteIfExists(tmp);
+      } catch (IOException ignored) {
+        // Nothing useful left to do.
+      }
+      throw e;
+    }
+  }
+}

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/OpaCoverageReport.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/OpaCoverageReport.java
@@ -1,21 +1,25 @@
 package io.github.open_policy_agent.opa.jackson;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.open_policy_agent.opa.ir.policy.UnplannedRule;
 import io.github.open_policy_agent.opa.tracing.CoverageProfiler;
+import io.github.open_policy_agent.opa.tracing.CoverageReport;
+import io.github.open_policy_agent.opa.tracing.CoverageReport.FileCoverage;
 import io.github.open_policy_agent.opa.tracing.Position;
 import io.github.open_policy_agent.opa.tracing.Range;
 
 /**
- * Serializes a {@link CoverageProfiler}'s collected coverage into the JSON shape produced by OPA's
- * {@code opa eval --coverage} command.
+ * Encodes a {@link CoverageReport} into the JSON shape produced by OPA's {@code opa eval
+ * --coverage} command, using Jackson.
+ *
+ * <p>The coverage semantics (covered vs. not-covered ranges, line counts, percentage) are
+ * computed upstream by {@link CoverageReport}; this class only maps that model onto Jackson nodes.
+ * It does no I/O ({@link JacksonCoverageReportWriter} calls it and writes the result out), so the
+ * report can be built and asserted on without touching disk.
  *
  * <p>Output structure:
  *
@@ -23,23 +27,27 @@ import io.github.open_policy_agent.opa.tracing.Range;
  * {
  *   "files": {
  *     "policy.rego": {
- *       "covered": [ { "start": { "row": 5, "col": 2 }, "end": { "row": 5, "col": 14 } } ]
+ *       "covered": [ { "start": { "row": 5, "col": 2 }, "end": { "row": 5, "col": 14 } } ],
+ *       "not_covered": [ { "start": { "row": 11, "col": 1 }, "end": { "row": 11, "col": 15 } } ],
+ *       "covered_lines": 1,
+ *       "not_covered_lines": 1,
+ *       "coverage": 50.0
  *     }
- *   }
+ *   },
+ *   "covered_lines": 1,
+ *   "not_covered_lines": 1,
+ *   "coverage": 50.0
  * }
  * }</pre>
  *
- * <p>Each executed statement range is emitted individually (sorted by position, not coalesced),
- * matching OPA's {@code v1/cover} report; a range's column is omitted when zero. File indices that
- * fall outside the provided filename list are skipped silently — those typically come from
- * synthetic statements with no source mapping.
+ * <p>A range's column is omitted when zero, matching OPA's {@code col,omitempty}.
  */
 public final class OpaCoverageReport {
 
   private OpaCoverageReport() {}
 
   /**
-   * Build the OPA-format coverage report.
+   * Build the OPA-format coverage report JSON.
    *
    * @param profiler the profiler that recorded coverage during evaluation
    * @param filenames file index -&gt; filename mapping, typically obtained via
@@ -47,33 +55,65 @@ public final class OpaCoverageReport {
    * @return a Jackson {@link ObjectNode} with the OPA coverage shape
    */
   public static ObjectNode from(CoverageProfiler profiler, List<String> filenames) {
+    return from(profiler, filenames, List.of());
+  }
+
+  /**
+   * Build the coverage report JSON, adding {@code not_covered} entries for rules that were never
+   * compiled into statements.
+   *
+   * @param profiler the profiler that recorded coverage during evaluation
+   * @param filenames file index -&gt; filename mapping, typically obtained via
+   *     {@code policy.getStaticField().getFiles()} mapped to {@code StringConst::getValue}
+   * @param unplannedRules rules to report as not covered, typically obtained via
+   *     {@code policy.getUnplannedRules()}
+   * @return a Jackson {@link ObjectNode} with the OPA coverage shape
+   */
+  public static ObjectNode from(
+      CoverageProfiler profiler, List<String> filenames, List<UnplannedRule> unplannedRules) {
+    return toJson(CoverageReport.from(profiler, filenames, unplannedRules));
+  }
+
+  /**
+   * Encode a computed {@link CoverageReport} into OPA's coverage JSON shape.
+   *
+   * @param report the library-neutral report to serialize
+   * @return a Jackson {@link ObjectNode} with the OPA coverage shape
+   */
+  public static ObjectNode toJson(CoverageReport report) {
     ObjectNode root = JsonNodeFactory.instance.objectNode();
     ObjectNode filesNode = root.putObject("files");
 
-    Map<Integer, Set<Range>> coveredByFile = profiler.getCoveredRanges();
-
-    List<Integer> fileIndices = new ArrayList<>(coveredByFile.keySet());
-    Collections.sort(fileIndices);
-
-    for (int fileIndex : fileIndices) {
-      if (fileIndex < 0 || fileIndex >= filenames.size()) {
-        continue;
+    for (Map.Entry<String, FileCoverage> entry : report.files().entrySet()) {
+      FileCoverage fileCoverage = entry.getValue();
+      ObjectNode fileEntry = filesNode.putObject(entry.getKey());
+      if (!fileCoverage.covered().isEmpty()) {
+        writeRanges(fileEntry.putArray("covered"), fileCoverage.covered());
       }
-      Set<Range> covered = coveredByFile.get(fileIndex);
-      if (covered == null || covered.isEmpty()) {
-        continue;
+      if (!fileCoverage.notCovered().isEmpty()) {
+        writeRanges(fileEntry.putArray("not_covered"), fileCoverage.notCovered());
       }
-      ObjectNode fileEntry = filesNode.putObject(filenames.get(fileIndex));
-      writeRanges(fileEntry.putArray("covered"), covered);
+      writeTotals(
+          fileEntry,
+          fileCoverage.coveredLines(),
+          fileCoverage.notCoveredLines(),
+          fileCoverage.coverage());
     }
+
+    writeTotals(root, report.coveredLines(), report.notCoveredLines(), report.coverage());
 
     return root;
   }
 
-  private static void writeRanges(ArrayNode array, Collection<Range> ranges) {
-    List<Range> sorted = new ArrayList<>(ranges);
-    sorted.sort(Range::compareTo);
-    for (Range range : sorted) {
+  private static void writeTotals(
+      ObjectNode node, int coveredLines, int notCoveredLines, double coverage) {
+    node.put("covered_lines", coveredLines);
+    node.put("not_covered_lines", notCoveredLines);
+    node.put("coverage", coverage);
+  }
+
+  private static void writeRanges(ArrayNode array, List<Range> ranges) {
+    for (Range range : ranges) {
       ObjectNode rangeNode = array.addObject();
       writePosition(rangeNode.putObject("start"), range.start());
       writePosition(rangeNode.putObject("end"), range.end());

--- a/opa-jackson/src/main/resources/META-INF/services/io.github.open_policy_agent.opa.tracing.CoverageReportWriter
+++ b/opa-jackson/src/main/resources/META-INF/services/io.github.open_policy_agent.opa.tracing.CoverageReportWriter
@@ -1,0 +1,1 @@
+io.github.open_policy_agent.opa.jackson.JacksonCoverageReportWriter

--- a/opa-jackson/src/test/java/io/github/open_policy_agent/opa/jackson/OpaCoverageReportTest.java
+++ b/opa-jackson/src/test/java/io/github/open_policy_agent/opa/jackson/OpaCoverageReportTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 import io.github.open_policy_agent.opa.ir.Location;
+import io.github.open_policy_agent.opa.ir.policy.UnplannedRule;
 import io.github.open_policy_agent.opa.tracing.CoverageProfiler;
 
 class OpaCoverageReportTest {
@@ -78,5 +79,79 @@ class OpaCoverageReportTest {
     JsonNode files = report.path("files");
     assertEquals(1, files.size());
     assertFalse(files.has("7"));
+  }
+
+  @Test
+  void unplannedRules_emitNotCoveredRanges() {
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(new Location(0, 1, 5, 10, 5), 0);
+    List<UnplannedRule> unplannedRules =
+        List.of(new UnplannedRule("data.example.unused", new Location(0, 1, 11, 15, 11)));
+
+    ObjectNode report = OpaCoverageReport.from(profiler, List.of("policy.rego"), unplannedRules);
+
+    JsonNode file = report.path("files").path("policy.rego");
+    assertEquals(1, file.path("covered").size());
+
+    JsonNode notCovered = file.path("not_covered");
+    assertEquals(1, notCovered.size());
+    assertEquals(11, notCovered.get(0).path("start").path("row").asInt());
+    assertEquals(1, notCovered.get(0).path("start").path("col").asInt());
+    assertEquals(11, notCovered.get(0).path("end").path("row").asInt());
+    assertEquals(15, notCovered.get(0).path("end").path("col").asInt());
+  }
+
+  @Test
+  void unplannedRules_withoutExecution_stillEmitFileEntry() {
+    CoverageProfiler profiler = new CoverageProfiler();
+    List<UnplannedRule> unplannedRules =
+        List.of(new UnplannedRule("data.example.unused", new Location(0, 1, 11, 15, 11)));
+
+    ObjectNode report = OpaCoverageReport.from(profiler, List.of("policy.rego"), unplannedRules);
+
+    JsonNode file = report.path("files").path("policy.rego");
+    assertFalse(file.has("covered"));
+    assertEquals(1, file.path("not_covered").size());
+  }
+
+  @Test
+  void twoArgOverload_neverEmitsNotCovered() {
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(new Location(0, 1, 5, 10, 5), 0);
+
+    ObjectNode report = OpaCoverageReport.from(profiler, List.of("policy.rego"));
+
+    assertFalse(report.path("files").path("policy.rego").has("not_covered"));
+  }
+
+  @Test
+  void summaryKeys_countDistinctLinesPerFileAndOverall() {
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(new Location(0, 1, 5, 10, 5), 0); // covered row 5
+    List<UnplannedRule> unplannedRules =
+        List.of(
+            // not covered rows 11..12 (a two-line rule body)
+            new UnplannedRule("data.example.unused", new Location(0, 1, 11, 15, 12)));
+
+    ObjectNode report = OpaCoverageReport.from(profiler, List.of("policy.rego"), unplannedRules);
+
+    JsonNode file = report.path("files").path("policy.rego");
+    assertEquals(1, file.path("covered_lines").asInt());
+    assertEquals(2, file.path("not_covered_lines").asInt());
+    assertEquals(1.0 / 3 * 100, file.path("coverage").asDouble());
+
+    // Top-level totals mirror the single file.
+    assertEquals(1, report.path("covered_lines").asInt());
+    assertEquals(2, report.path("not_covered_lines").asInt());
+    assertEquals(1.0 / 3 * 100, report.path("coverage").asDouble());
+  }
+
+  @Test
+  void coverage_isZeroWhenNothingRecorded() {
+    ObjectNode report = OpaCoverageReport.from(new CoverageProfiler(), List.of("policy.rego"));
+
+    assertEquals(0, report.path("covered_lines").asInt());
+    assertEquals(0, report.path("not_covered_lines").asInt());
+    assertEquals(0.0, report.path("coverage").asDouble());
   }
 }


### PR DESCRIPTION
This gives the SDK the option of saving coverage reports to disk.

This is useful so that an external caller can trigger the writing of reports to a known location on disk without needing to modify the SDK.

This is not intended for production use cases, but rather Java IDE integrations showing coverage reporting.