### PR TITLE
fix(metrics): implement SimpleMetrics counter and histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Runtime, SDK, Tooling
+
+- Implement `SimpleMetrics.counter()` and `SimpleMetrics.histogram()`, which
+  previously returned `null` and made every caller of those metric types throw a
+  `NullPointerException`. Counters and histograms are now also reported by
+  `all()`, so they reach `MetricsPrinter` and decision logs
+
 ## 0.4.0
 
 This release brings the builtin surface to 156, adding 46 builtins: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ project adheres to [Semantic Versioning](http://semver.org/).
   previously returned `null` and made every caller of those metric types throw a
   `NullPointerException`. Counters and histograms are now also reported by
   `all()`, so they reach `MetricsPrinter` and decision logs
+- Emit counters and histograms in decision log events under the names OPA Go
+  publishes them as, `counter_<name>` and `histogram_<name>`. Neither exposes a
+  Jackson-visible property, so the previous default serialization threw and
+  `logDecision` dropped the entire decision event, not just the metric
+- Serialize `Metrics.Counter` and `Metrics.Histogram` via `MetricsModule`, which
+  previously covered only `Metrics.Timer`
+- Saturate `SimpleMetrics` histogram stats at the `int` bounds instead of
+  wrapping. `Histogram.Values` holds `int`s, but nanosecond timings pass
+  `Integer.MAX_VALUE` after 2.15s, so a 3s sample reported `-1294967296`
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
   previously covered only `Metrics.Timer`
 - Saturate `SimpleMetrics` histogram stats at the `int` bounds instead of
   wrapping. `Histogram.Values` holds `int`s, but nanosecond timings pass
-  `Integer.MAX_VALUE` after 2.15s, so a 3s sample reported `-1294967296`
+  `Integer.MAX_VALUE` after 2.147s, so a 3s sample reported `-1294967296` for
+  every stat, and the sign flipped both ways
 
 ## 0.4.0
 

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/SimpleMetrics.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/SimpleMetrics.java
@@ -1,13 +1,20 @@
 package io.github.open_policy_agent.opa.metrics;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class SimpleMetrics implements Metrics {
 
   private final Map<String, Timer> timers = new TreeMap<>();
+  private final Map<String, Counter> counters = new ConcurrentHashMap<>();
+  private final Map<String, Histogram> histograms = new ConcurrentHashMap<>();
 
   @Override
   public String name() {
@@ -43,21 +50,129 @@ public class SimpleMetrics implements Metrics {
 
   @Override
   public Histogram histogram(String name) {
-    return null;
+    return histograms.computeIfAbsent(name, key -> new SimpleHistogram());
   }
 
   @Override
   public Counter counter(String name) {
-    return null;
+    return counters.computeIfAbsent(name, key -> new SimpleCounter());
   }
 
   @Override
   public Map<String, Metric> all() {
-    return new TreeMap<>(timers);
+    Map<String, Metric> all = new TreeMap<>(timers);
+    all.putAll(counters);
+    all.putAll(histograms);
+    return all;
   }
 
   @Override
   public void clear() {
     timers.clear();
+    counters.clear();
+    histograms.clear();
+  }
+
+  private static class SimpleCounter implements Counter {
+
+    private final AtomicInteger value = new AtomicInteger();
+
+    @Override
+    public void add(int delta) {
+      value.addAndGet(delta);
+    }
+
+    @Override
+    public void incr() {
+      value.incrementAndGet();
+    }
+
+    @Override
+    public int value() {
+      return value.get();
+    }
+  }
+
+  /**
+   * Histogram over a bounded reservoir. Once {@code RESERVOIR_SIZE} samples have been recorded,
+   * further updates replace a random slot (Vitter's algorithm R) so a long-lived {@link Metrics}
+   * instance does not grow without bound. The reservoir size and the reported percentiles match
+   * OPA's Go implementation, which draws both from {@code rcrowley/go-metrics}.
+   */
+  private static class SimpleHistogram implements Histogram {
+
+    private static final int RESERVOIR_SIZE = 1028;
+    private static final double[] PERCENTILES = {0.75, 0.9, 0.95, 0.99, 0.999, 0.9999};
+    private static final String[] PERCENTILE_KEYS = {"75%", "90%", "95%", "99%", "99.9%", "99.99%"};
+
+    private final double[] reservoir = new double[RESERVOIR_SIZE];
+    private long count;
+    private int size;
+
+    @Override
+    public synchronized void update(double value) {
+      count++;
+      if (size < RESERVOIR_SIZE) {
+        reservoir[size] = value;
+        size++;
+        return;
+      }
+      long slot = ThreadLocalRandom.current().nextLong(count);
+      if (slot < RESERVOIR_SIZE) {
+        reservoir[(int) slot] = value;
+      }
+    }
+
+    @Override
+    public synchronized Values value() {
+      Values values = new Values();
+      values.percentiles = new HashMap<>();
+      // count is the number of updates, not the reservoir occupancy; saturate rather than wrap.
+      values.count = (int) Math.min(count, Integer.MAX_VALUE);
+      if (size == 0) {
+        return values;
+      }
+
+      double[] sorted = Arrays.copyOf(reservoir, size);
+      Arrays.sort(sorted);
+      double sum = 0;
+      for (double sample : sorted) {
+        sum += sample;
+      }
+      double mean = sum / size;
+      double squaredDeviations = 0;
+      for (double sample : sorted) {
+        squaredDeviations += (sample - mean) * (sample - mean);
+      }
+
+      values.min = round(sorted[0]);
+      values.max = round(sorted[size - 1]);
+      values.mean = round(mean);
+      // Population standard deviation, as in go-metrics' SampleVariance.
+      values.stddev = round(Math.sqrt(squaredDeviations / size));
+      values.median = round(percentile(sorted, 0.5));
+      for (int i = 0; i < PERCENTILES.length; i++) {
+        values.percentiles.put(PERCENTILE_KEYS[i], round(percentile(sorted, PERCENTILES[i])));
+      }
+      return values;
+    }
+
+    /** Linearly interpolated percentile, matching go-metrics' {@code SamplePercentiles}. */
+    private static double percentile(double[] sorted, double quantile) {
+      double pos = quantile * (sorted.length + 1);
+      if (pos < 1.0) {
+        return sorted[0];
+      }
+      if (pos >= sorted.length) {
+        return sorted[sorted.length - 1];
+      }
+      double lower = sorted[(int) pos - 1];
+      double upper = sorted[(int) pos];
+      return lower + (pos - Math.floor(pos)) * (upper - lower);
+    }
+
+    private static int round(double value) {
+      return (int) Math.round(value);
+    }
   }
 }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/SimpleMetrics.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/SimpleMetrics.java
@@ -173,7 +173,7 @@ public class SimpleMetrics implements Metrics {
 
     private static int round(double value) {
       // Values' fields are int, but Go feeds histograms nanosecond timings, which pass
-      // Integer.MAX_VALUE after 2.15s. Saturate rather than let the cast wrap, as count does.
+      // Integer.MAX_VALUE after 2.147s. Saturate rather than let the cast wrap, as count does.
       return (int) Math.max(Integer.MIN_VALUE, Math.min(Integer.MAX_VALUE, Math.round(value)));
     }
   }

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/SimpleMetrics.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/metrics/SimpleMetrics.java
@@ -172,7 +172,9 @@ public class SimpleMetrics implements Metrics {
     }
 
     private static int round(double value) {
-      return (int) Math.round(value);
+      // Values' fields are int, but Go feeds histograms nanosecond timings, which pass
+      // Integer.MAX_VALUE after 2.15s. Saturate rather than let the cast wrap, as count does.
+      return (int) Math.max(Integer.MIN_VALUE, Math.min(Integer.MAX_VALUE, Math.round(value)));
     }
   }
 }

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/SimpleMetricsTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/SimpleMetricsTest.java
@@ -1,0 +1,135 @@
+package io.github.open_policy_agent.opa.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.open_policy_agent.opa.metrics.Metrics.Counter;
+import io.github.open_policy_agent.opa.metrics.Metrics.Histogram;
+import io.github.open_policy_agent.opa.metrics.Metrics.Metric;
+import io.github.open_policy_agent.opa.metrics.Metrics.Timer;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SimpleMetricsTest {
+
+  @Test
+  void counter_isRegisteredOnceAndAccumulates() {
+    SimpleMetrics metrics = new SimpleMetrics();
+
+    Counter counter = metrics.counter("hits");
+    assertNotNull(counter, "counter(String) must not return null");
+    assertSame(counter, metrics.counter("hits"), "repeated lookups must return the same counter");
+
+    assertEquals(0, counter.value());
+    counter.incr();
+    counter.add(41);
+    assertEquals(42, counter.value());
+  }
+
+  @Test
+  void histogram_isRegisteredOnce() {
+    SimpleMetrics metrics = new SimpleMetrics();
+
+    Histogram histogram = metrics.histogram("sizes");
+    assertNotNull(histogram, "histogram(String) must not return null");
+    assertSame(
+        histogram, metrics.histogram("sizes"), "repeated lookups must return the same histogram");
+  }
+
+  @Test
+  void histogram_withoutUpdates_reportsZeros() {
+    Histogram.Values values = new SimpleMetrics().histogram("sizes").value();
+
+    assertEquals(0, values.count);
+    assertEquals(0, values.min);
+    assertEquals(0, values.max);
+    assertEquals(0, values.mean);
+    assertEquals(0, values.stddev);
+    assertEquals(0, values.median);
+    assertNotNull(values.percentiles);
+  }
+
+  @Test
+  void histogram_reportsStatsMatchingGoMetrics() {
+    SimpleMetrics metrics = new SimpleMetrics();
+    Histogram histogram = metrics.histogram("sizes");
+    for (int i = 1; i <= 9; i++) {
+      histogram.update(i);
+    }
+
+    Histogram.Values values = histogram.value();
+
+    assertEquals(9, values.count);
+    assertEquals(1, values.min);
+    assertEquals(9, values.max);
+    assertEquals(5, values.mean);
+    // Population stddev of 1..9 is sqrt(60/9) = 2.58, rounded to 3.
+    assertEquals(3, values.stddev);
+    assertEquals(5, values.median);
+    // go-metrics interpolates: the 75th percentile sits at position 0.75 * (9 + 1) = 7.5,
+    // i.e. halfway between the 7th and 8th samples.
+    assertEquals(8, values.percentiles.get("75%"));
+    // Positions at or past the sample count clamp to the largest sample.
+    assertEquals(9, values.percentiles.get("90%"));
+    assertEquals(9, values.percentiles.get("95%"));
+    assertEquals(9, values.percentiles.get("99%"));
+    assertEquals(9, values.percentiles.get("99.9%"));
+    assertEquals(9, values.percentiles.get("99.99%"));
+  }
+
+  @Test
+  void histogram_beyondReservoirCapacity_keepsCountingUpdates() {
+    Histogram histogram = new SimpleMetrics().histogram("sizes");
+    for (int i = 0; i < 5000; i++) {
+      histogram.update(7);
+    }
+
+    Histogram.Values values = histogram.value();
+
+    assertEquals(5000, values.count);
+    assertEquals(7, values.min);
+    assertEquals(7, values.max);
+    assertEquals(7, values.median);
+  }
+
+  @Test
+  void all_containsEveryRegisteredMetricType() {
+    SimpleMetrics metrics = new SimpleMetrics();
+    metrics.timer("rego_query_eval");
+    metrics.counter("hits");
+    metrics.histogram("sizes");
+
+    Map<String, Metric> all = metrics.all();
+
+    assertTrue(all.get("rego_query_eval") instanceof Timer, "timer missing from all()");
+    assertTrue(all.get("hits") instanceof Counter, "counter missing from all()");
+    assertTrue(all.get("sizes") instanceof Histogram, "histogram missing from all()");
+  }
+
+  @Test
+  void clear_removesEveryMetricType() {
+    SimpleMetrics metrics = new SimpleMetrics();
+    metrics.timer("rego_query_eval");
+    metrics.counter("hits");
+    metrics.histogram("sizes");
+
+    metrics.clear();
+
+    assertTrue(metrics.all().isEmpty(), "clear() must drop timers, counters and histograms");
+  }
+
+  @Test
+  void printer_rendersCounterAndHistogramRows() {
+    SimpleMetrics metrics = new SimpleMetrics();
+    metrics.counter("hits").add(3);
+    metrics.histogram("sizes").update(11);
+
+    String table = MetricsPrinter.metricsToString(metrics);
+
+    assertTrue(table.contains("counter_hits"), table);
+    assertTrue(table.contains("histogram_sizes_count"), table);
+    assertTrue(table.contains("histogram_sizes_99.99%"), table);
+  }
+}

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/SimpleMetricsTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/SimpleMetricsTest.java
@@ -132,4 +132,31 @@ class SimpleMetricsTest {
     assertTrue(table.contains("histogram_sizes_count"), table);
     assertTrue(table.contains("histogram_sizes_99.99%"), table);
   }
+
+  @Test
+  void histogram_saturatesStatsAboveIntRange() {
+    // Go feeds histograms nanosecond timings, and Integer.MAX_VALUE nanoseconds is only 2.15s.
+    // Values' fields are int, so saturate the way count already does rather than wrap negative.
+    Histogram histogram = new SimpleMetrics().histogram("eval_ns");
+    histogram.update(3e9);
+
+    Histogram.Values values = histogram.value();
+
+    assertEquals(Integer.MAX_VALUE, values.min);
+    assertEquals(Integer.MAX_VALUE, values.max);
+    assertEquals(Integer.MAX_VALUE, values.mean);
+    assertEquals(Integer.MAX_VALUE, values.median);
+    assertEquals(Integer.MAX_VALUE, values.percentiles.get("99%"));
+  }
+
+  @Test
+  void histogram_saturatesStatsBelowIntRange() {
+    Histogram histogram = new SimpleMetrics().histogram("drift");
+    histogram.update(-3e9);
+
+    Histogram.Values values = histogram.value();
+
+    assertEquals(Integer.MIN_VALUE, values.min);
+    assertEquals(Integer.MIN_VALUE, values.max);
+  }
 }

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/SimpleMetricsTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/metrics/SimpleMetricsTest.java
@@ -135,7 +135,7 @@ class SimpleMetricsTest {
 
   @Test
   void histogram_saturatesStatsAboveIntRange() {
-    // Go feeds histograms nanosecond timings, and Integer.MAX_VALUE nanoseconds is only 2.15s.
+    // Go feeds histograms nanosecond timings, and Integer.MAX_VALUE nanoseconds is only 2.147s.
     // Values' fields are int, so saturate the way count already does rather than wrap negative.
     Histogram histogram = new SimpleMetrics().histogram("eval_ns");
     histogram.update(3e9);

--- a/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/MetricsModule.java
+++ b/opa-jackson/src/main/java/io/github/open_policy_agent/opa/jackson/MetricsModule.java
@@ -7,12 +7,15 @@ import io.github.open_policy_agent.opa.metrics.SimpleMetrics;
 import java.time.Duration;
 
 /**
- * Jackson {@link SimpleModule} that adds {@code @JsonValue} behavior to {@link SimpleMetrics}'s inner {@code Timer}.
+ * Jackson {@link SimpleModule} that adds {@code @JsonValue} behavior to {@link SimpleMetrics}'s inner metrics.
  * Register this module to have {@link Metrics.Timer} serialize as the underlying
- * {@link Duration} value rather than a default bean.
+ * {@link Duration} value, {@link Metrics.Counter} as its {@code int} value and
+ * {@link Metrics.Histogram} as its {@link Metrics.Histogram.Values} stats, rather than as default
+ * beans. None of them expose a Jackson-visible property, so without these mixins serializing one
+ * fails outright.
  *
- * <p>Applied at the {@link Metrics.Timer} interface level via a mixin, so it covers any Timer
- * implementation, not just the one returned by {@link SimpleMetrics}.
+ * <p>Applied at the {@link Metrics} interface level via mixins, so they cover any implementation,
+ * not just the ones returned by {@link SimpleMetrics}.
  *
  * <p>Usage:
  *
@@ -26,10 +29,22 @@ public class MetricsModule extends SimpleModule {
   public MetricsModule() {
     super("opa-metrics");
     setMixInAnnotation(Metrics.Timer.class, TimerMixin.class);
+    setMixInAnnotation(Metrics.Counter.class, CounterMixin.class);
+    setMixInAnnotation(Metrics.Histogram.class, HistogramMixin.class);
   }
 
-  abstract static class TimerMixin {
+  interface TimerMixin {
     @JsonValue
-    abstract Duration value();
+    Duration value();
+  }
+
+  interface CounterMixin {
+    @JsonValue
+    int value();
+  }
+
+  interface HistogramMixin {
+    @JsonValue
+    Metrics.Histogram.Values value();
   }
 }

--- a/opa-jackson/src/test/java/io/github/open_policy_agent/opa/jackson/MetricsModuleTest.java
+++ b/opa-jackson/src/test/java/io/github/open_policy_agent/opa/jackson/MetricsModuleTest.java
@@ -31,4 +31,27 @@ class MetricsModuleTest {
     // serializing its underlying Duration produces.
     assertThat(timerJson).isEqualTo(durationJson);
   }
+
+  @Test
+  void counter_serializesAsItsValue() throws IOException {
+    SimpleMetrics metrics = new SimpleMetrics();
+    Metrics.Counter counter = metrics.counter("server_query_cache_hit");
+    counter.add(3);
+
+    // Without the mixin a Counter has no Jackson-visible property and serialization fails
+    // outright, so asserting the shape also asserts that it serializes at all.
+    assertThat(mapper.writeValueAsString(counter)).isEqualTo("3");
+  }
+
+  @Test
+  void histogram_serializesAsItsStats() throws IOException {
+    SimpleMetrics metrics = new SimpleMetrics();
+    Metrics.Histogram histogram = metrics.histogram("sizes");
+    histogram.update(11);
+
+    String histogramJson = mapper.writeValueAsString(histogram);
+
+    assertThat(histogramJson).isEqualTo(mapper.writeValueAsString(histogram.value()));
+    assertThat(histogramJson).contains("\"count\":1", "\"99%\":11");
+  }
 }

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/DecisionLogPlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/DecisionLogPlugin.java
@@ -590,21 +590,7 @@ public final class DecisionLogPlugin implements Plugin {
       if (metrics != null) {
         ObjectNode metricsNode = MAPPER.createObjectNode();
 
-        metrics
-            .all()
-            .forEach(
-                (key, value) -> {
-                  // Convert Timer metrics to nanoseconds with proper naming
-                  if (value instanceof Metrics.Timer) {
-                    Metrics.Timer timer = (Metrics.Timer) value;
-                    long nanos = timer.value().toNanos();
-                    String metricName = "timer_" + key + "_ns";
-                    metricsNode.put(metricName, nanos);
-                  } else {
-                    // For other metric types, use default serialization
-                    metricsNode.set(key, MAPPER.valueToTree(value));
-                  }
-                });
+        metrics.all().forEach((key, value) -> addMetric(metricsNode, key, value));
         event.set("metrics", metricsNode);
       }
 
@@ -640,6 +626,41 @@ public final class DecisionLogPlugin implements Plugin {
       }
 
       return event;
+    }
+
+    /**
+     * Add one metric to the event's {@code metrics} object under the name OPA Go publishes it as
+     * (see {@code metrics.formatKey}): {@code timer_<name>_ns}, {@code counter_<name>} and
+     * {@code histogram_<name>}.
+     *
+     * <p>The three known types are written out field by field rather than handed to Jackson:
+     * none of them exposes a Jackson-visible property, so default serialization throws and
+     * {@code logDecision} drops the whole decision event rather than one metric. Any other
+     * implementation still falls back to Jackson under its bare name, as Go's default branch does.
+     */
+    private static void addMetric(ObjectNode metricsNode, String key, Metrics.Metric metric) {
+      if (metric instanceof Metrics.Timer) {
+        metricsNode.put("timer_" + key + "_ns", ((Metrics.Timer) metric).value().toNanos());
+      } else if (metric instanceof Metrics.Counter) {
+        metricsNode.put("counter_" + key, ((Metrics.Counter) metric).value());
+      } else if (metric instanceof Metrics.Histogram) {
+        Metrics.Histogram.Values values = ((Metrics.Histogram) metric).value();
+        if (values == null) {
+          return;
+        }
+        ObjectNode stats = metricsNode.putObject("histogram_" + key);
+        stats.put("count", values.count);
+        stats.put("min", values.min);
+        stats.put("max", values.max);
+        stats.put("mean", values.mean);
+        stats.put("stddev", values.stddev);
+        stats.put("median", values.median);
+        if (values.percentiles != null) {
+          values.percentiles.forEach(stats::put);
+        }
+      } else {
+        metricsNode.set(key, MAPPER.valueToTree(metric));
+      }
     }
 
     /** Flush buffered decisions to service. */

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/DecisionLogPluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/DecisionLogPluginTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import io.github.open_policy_agent.opa.config.Config;
 import io.github.open_policy_agent.opa.logging.Logger;
+import io.github.open_policy_agent.opa.metrics.Metrics;
 import io.github.open_policy_agent.opa.metrics.SimpleMetrics;
 import io.github.open_policy_agent.opa.storage.InMem;
 import io.github.open_policy_agent.opa.storage.Store;
@@ -764,5 +765,51 @@ class DecisionLogPluginTest {
     assertEquals(3, metricsNode.get("counter_server_query_cache_hit").asInt());
     assertEquals(1, metricsNode.get("histogram_eval_ns").get("count").asInt());
     assertEquals(11, metricsNode.get("histogram_eval_ns").get("99%").asInt());
+  }
+
+  /** A Metric that is none of the three known types, but is serializable by Jackson. */
+  private static final class CustomMetric implements Metrics.Metric {
+    public int getValue() {
+      return 7;
+    }
+  }
+
+  @Test
+  void decisionLogs_unknownMetricType_fallsBackToItsBareName() {
+    Config.DecisionLogsConfig decisionLogs =
+        new Config.DecisionLogsConfig().setConsole(true).setService("test-service");
+    config.setDecisionLogs(decisionLogs);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    DecisionLogPlugin plugin = new DecisionLogPlugin();
+    plugin = (DecisionLogPlugin) plugin.initialize(manager);
+    plugin.start();
+
+    // Metrics is a public interface, so an implementation can report metrics that are none of
+    // Timer/Counter/Histogram. Go's formatKey keeps those under the bare name; so do we.
+    Metrics metrics = mock(Metrics.class);
+    when(metrics.all()).thenReturn(Collections.singletonMap("custom", new CustomMetric()));
+
+    JsonNode input = mapper.createObjectNode().put("user", "frank");
+    JsonNode result = mapper.createObjectNode().put("allow", true);
+
+    plugin
+        .getDecisionLogs()
+        .logDecision("decision-custom", input, result, "data.authz.allow", null, 0, metrics, null);
+
+    verify(mockLogger, never()).error(anyString(), any());
+
+    ArgumentCaptor<String> logged = ArgumentCaptor.forClass(String.class);
+    verify(mockLogger, atLeastOnce()).info(eq("Decision: %s"), logged.capture());
+    JsonNode event = assertDoesNotThrow(() -> mapper.readTree(logged.getValue()));
+
+    assertEquals(7, event.get("metrics").get("custom").get("value").asInt());
   }
 }

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/DecisionLogPluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/DecisionLogPluginTest.java
@@ -9,8 +9,10 @@ import java.util.Collections;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import io.github.open_policy_agent.opa.config.Config;
 import io.github.open_policy_agent.opa.logging.Logger;
+import io.github.open_policy_agent.opa.metrics.SimpleMetrics;
 import io.github.open_policy_agent.opa.storage.InMem;
 import io.github.open_policy_agent.opa.storage.Store;
 
@@ -714,5 +716,53 @@ class DecisionLogPluginTest {
 
     // Verify no errors occurred
     verify(mockLogger, never()).error(anyString(), any());
+  }
+
+  @Test
+  void decisionLogs_includesEveryMetricType() {
+    Config.DecisionLogsConfig decisionLogs =
+        new Config.DecisionLogsConfig().setConsole(true).setService("test-service");
+    config.setDecisionLogs(decisionLogs);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    DecisionLogPlugin plugin = new DecisionLogPlugin();
+    plugin = (DecisionLogPlugin) plugin.initialize(manager);
+    plugin.start();
+
+    DecisionLogPlugin.DecisionLogs decisionLogger = plugin.getDecisionLogs();
+
+    SimpleMetrics metrics = new SimpleMetrics();
+    metrics.timer("rego_query_eval").start();
+    metrics.timer("rego_query_eval").stop();
+    metrics.counter("server_query_cache_hit").add(3);
+    metrics.histogram("eval_ns").update(11);
+
+    JsonNode input = mapper.createObjectNode().put("user", "erin");
+    JsonNode result = mapper.createObjectNode().put("allow", true);
+
+    decisionLogger.logDecision(
+        "decision-metrics", input, result, "data.authz.allow", null, 0, metrics, null);
+
+    // Counters and histograms have no Jackson-visible property, so default serialization throws
+    // and logDecision swallows it — dropping the whole event, not just the metric.
+    verify(mockLogger, never()).error(anyString(), any());
+
+    ArgumentCaptor<String> logged = ArgumentCaptor.forClass(String.class);
+    verify(mockLogger, atLeastOnce()).info(eq("Decision: %s"), logged.capture());
+    JsonNode event = assertDoesNotThrow(() -> mapper.readTree(logged.getValue()));
+    JsonNode metricsNode = event.get("metrics");
+
+    // Key naming follows Go's metrics.formatKey: timer_<name>_ns, counter_<name>, histogram_<name>.
+    assertTrue(metricsNode.has("timer_rego_query_eval_ns"), metricsNode.toString());
+    assertEquals(3, metricsNode.get("counter_server_query_cache_hit").asInt());
+    assertEquals(1, metricsNode.get("histogram_eval_ns").get("count").asInt());
+    assertEquals(11, metricsNode.get("histogram_eval_ns").get("99%").asInt());
   }
 }


### PR DESCRIPTION
Fixes #60

### Summary

`SimpleMetrics` only implemented `Timer`. `histogram(String)` and `counter(String)`
returned `null`, so any caller of those metric types threw an NPE, and `all()`
returned only the timer map, so neither type ever reached `MetricsPrinter`.

### Changes

- `Counter` backed by an `AtomicInteger`. The issue suggests `AtomicLong`/`LongAdder`,
  but `Metrics.Counter` declares `add(int)` and `int value()`, so a long accumulator
  would only add a lossy narrowing at the boundary.
- `Histogram` over a bounded reservoir of 1028 samples — the size Go-OPA takes from
  `rcrowley/go-metrics` — replacing a random slot once full, so a long-lived `Metrics`
  instance cannot grow without bound. Statistics follow the Go implementation:
  population standard deviation (`SampleVariance` divides by `N`) and the linearly
  interpolated `SamplePercentiles`, at Go's hardcoded set (`median`, `75%`, `90%`,
  `95%`, `99%`, `99.9%`, `99.99%`). `count` is the number of updates, not the reservoir
  occupancy, matching `snap.Count()`.
- `all()` and `clear()` now cover all three metric types.
- `Histogram.Values` keeps its `int` fields, so the rows `MetricsPrinterTest` asserts
  are unchanged.
- The timer map and the inline `Timer` are untouched — that is #56. The new
  counter/histogram code is thread-safe as written.

### Verification

- `./gradlew :opa-evaluator:test :opa-evaluator:checkstyleMain :opa-evaluator:checkstyleTest
  :opa-evaluator:pmdMain :opa-evaluator:pmdTest` — no PMD findings, and no Checkstyle
  findings for `SimpleMetrics.java`. `SimpleMetricsTest` picks up the usual `MethodName`
  warnings for `snake_case` test names, as the existing test sources do (#88).
- Adds `SimpleMetricsTest`, 8 cases. Reverting only `SimpleMetrics.java` fails 7 of the
  8; the 8th covers `clear()`, which passes trivially when nothing can be registered.
- `./gradlew build`: the only remaining failures are `json_match_schema/invalid document`
  and `:opa-proto:vendorProtoSchemas`. The first reproduces unchanged with my change
  reverted; the second is `go mod download` unable to reach `proxy.golang.org` from here.

### Open questions

1. The issue asks for configurable percentiles, but upstream Go is explicitly "a
   histogram with hardcoded percentiles" and CONTRIBUTING asks to keep the public
   surface minimal, so I matched Go. Happy to add a constructor overload if you would
   rather have it configurable.
2. `mean` and `stddev` are `float64` in Go but `int` in `Histogram.Values`, so precision
   is lost. Widening them is a public-API change that also rewrites the
   `MetricsPrinterTest` expectations — worth a separate issue?
