### PR TITLE
coverage: Report not_covered lines

### DIFF
--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageRecorder.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageRecorder.java
@@ -142,9 +142,7 @@ public final class CoverageRecorder {
       String baseName = "report-" + runId + "-" + index++;
       try {
         Policy policy = entry.getKey();
-        CoverageReport report =
-            CoverageReport.from(
-                entry.getValue(), policy.getStaticFilenames(), policy.getUnplannedRules());
+        CoverageReport report = CoverageReport.from(entry.getValue(), policy);
         writer.write(report, outputDir, baseName);
       } catch (Exception e) {
         // A shutdown hook cannot usefully propagate error. One bad report does not impact others.

--- a/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageReport.java
+++ b/opa-evaluator/src/main/java/io/github/open_policy_agent/opa/tracing/CoverageReport.java
@@ -1,10 +1,23 @@
 package io.github.open_policy_agent.opa.tracing;
 
+import io.github.open_policy_agent.opa.ir.Location;
+import io.github.open_policy_agent.opa.ir.policy.Block;
+import io.github.open_policy_agent.opa.ir.policy.Func;
+import io.github.open_policy_agent.opa.ir.policy.Plan;
+import io.github.open_policy_agent.opa.ir.policy.Policy;
+import io.github.open_policy_agent.opa.ir.policy.Static;
+import io.github.open_policy_agent.opa.ir.policy.StringConst;
 import io.github.open_policy_agent.opa.ir.policy.UnplannedRule;
+import io.github.open_policy_agent.opa.ir.stmts.BlockStmt;
+import io.github.open_policy_agent.opa.ir.stmts.NotStmt;
+import io.github.open_policy_agent.opa.ir.stmts.ScanStmt;
+import io.github.open_policy_agent.opa.ir.stmts.Stmt;
+import io.github.open_policy_agent.opa.ir.stmts.WithStmt;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,8 +34,11 @@ import java.util.TreeSet;
  * <p>Each executed statement range is reported individually, sorted by position and not coalesced,
  * matching OPA. {@code covered}/{@code notCovered} may be empty and the line counts count distinct
  * source rows. File indices outside {@code filenames} are skipped (synthetic statements with no
- * source mapping). {@code notCovered} ranges come from the plan's {@code unplanned_rules}: rules
- * the planner never compiled into statements, so they can never be covered.
+ * source mapping). {@code notCovered} ranges come from two sources. The first is statements the
+ * planner compiled but the evaluator never ran, e.g. the rest of a rule body after an earlier
+ * statement failed. These are found by walking every statement in the plan and reporting any whose
+ * range was not recorded as covered. The second is the plan's {@code unplanned_rules}: rules the
+ * planner never compiled into statements at all, so they can never be covered.
  */
 public record CoverageReport(
     Map<String, FileCoverage> files, int coveredLines, int notCoveredLines, double coverage) {
@@ -42,15 +58,18 @@ public record CoverageReport(
    * Build the report from recorded coverage.
    *
    * @param profiler the profiler that recorded coverage during evaluation
-   * @param filenames file index to filename mapping, typically {@code policy.getStaticFilenames()}
-   * @param unplannedRules rules to report as not covered, typically {@code
-   *     policy.getUnplannedRules()}; may be null
+   * @param policy the evaluated policy, used to resolve filenames, unplanned rules, and every
+   *     statement range the plan contains
    * @return the computed, library-neutral report
    */
-  public static CoverageReport from(
-      CoverageProfiler profiler, List<String> filenames, List<UnplannedRule> unplannedRules) {
+  public static CoverageReport from(CoverageProfiler profiler, Policy policy) {
+    List<String> filenames = policy.getStaticFilenames();
+    List<UnplannedRule> unplannedRules = policy.getUnplannedRules();
+    Map<Integer, Set<Range>> plannedRanges = plannedRangesByFile(policy);
+
     Map<Integer, Set<Range>> coveredByFile = profiler.getCoveredRanges();
-    Map<Integer, List<Range>> notCoveredByFile = notCoveredRangesByFile(unplannedRules);
+    Map<Integer, List<Range>> notCoveredByFile =
+        notCoveredRangesByFile(unplannedRules, plannedRanges, coveredByFile);
 
     Set<Integer> fileIndices = new TreeSet<>(coveredByFile.keySet());
     fileIndices.addAll(notCoveredByFile.keySet());
@@ -89,6 +108,140 @@ public record CoverageReport(
         files, totalCovered, totalNotCovered, coveragePercent(totalCovered, totalNotCovered));
   }
 
+  /**
+   * Build the report without statement-level not-covered detection, for callers with no
+   * {@link Policy} on hand. Wraps the inputs in a plan-less {@link Policy} and delegates to
+   * {@link #from(CoverageProfiler, Policy)}.
+   *
+   * @param profiler the profiler that recorded coverage during evaluation
+   * @param filenames file index to filename mapping, typically {@code policy.getStaticFilenames()}
+   * @param unplannedRules rules to report as not covered, typically {@code
+   *     policy.getUnplannedRules()}; may be null
+   * @return the computed, library-neutral report
+   */
+  public static CoverageReport from(
+      CoverageProfiler profiler, List<String> filenames, List<UnplannedRule> unplannedRules) {
+    List<StringConst> files = new ArrayList<>();
+    for (String filename : filenames) {
+      files.add(new StringConst(filename));
+    }
+    Policy policy = new Policy(new Static(List.of(), List.of(), files), null, null, unplannedRules);
+    return from(profiler, policy);
+  }
+
+  /**
+   * Ranges to report as not covered:
+   *
+   * <ul>
+   *   <li>{@code plannedRanges} entries absent from {@code coveredByFile} (a compiled statement
+   *       that never ran)
+   *   <li>every {@code unplannedRules} range (a rule the planner never compiled at all)
+   * </ul>
+   *
+   * <p>Membership uses {@link Range#contains}, not equality, matching OPA's {@code v1/cover}
+   * {@code isRangeCovered}: a covered range that fully contains the candidate counts as covered.
+   */
+  private static Map<Integer, List<Range>> notCoveredRangesByFile(
+      List<UnplannedRule> unplannedRules,
+      Map<Integer, Set<Range>> plannedRanges,
+      Map<Integer, Set<Range>> coveredByFile) {
+    Map<Integer, Set<Range>> byFile = new HashMap<>();
+    if (unplannedRules != null) {
+      for (UnplannedRule rule : unplannedRules) {
+        byFile
+            .computeIfAbsent(rule.getLocation().getFile(), k -> new LinkedHashSet<>())
+            .add(Range.of(rule.getLocation()));
+      }
+    }
+
+    if (plannedRanges != null) {
+      for (Map.Entry<Integer, Set<Range>> entry : plannedRanges.entrySet()) {
+        Set<Range> covered = coveredByFile.getOrDefault(entry.getKey(), Set.of());
+        for (Range range : entry.getValue()) {
+          if (!isRangeCovered(range, covered)) {
+            byFile.computeIfAbsent(entry.getKey(), k -> new LinkedHashSet<>()).add(range);
+          }
+        }
+      }
+    }
+
+    Map<Integer, List<Range>> result = new HashMap<>();
+    for (Map.Entry<Integer, Set<Range>> entry : byFile.entrySet()) {
+      result.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+    }
+    return result;
+  }
+
+  private static boolean isRangeCovered(Range range, Set<Range> covered) {
+    for (Range candidate : covered) {
+      if (candidate.contains(range)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Every statement range the plan contains, per file, regardless of whether it ran. This is the
+   * IR-level equivalent of walking a Rego AST's rules and expressions: a statement present here but
+   * absent from {@link CoverageProfiler#getCoveredRanges()} is reported as not covered, which
+   * catches the tail of a rule body that stopped executing partway through (e.g. after an earlier
+   * statement failed), not just whole rules the planner dropped.
+   */
+  private static Map<Integer, Set<Range>> plannedRangesByFile(Policy policy) {
+    Map<Integer, Set<Range>> byFile = new HashMap<>();
+    if (policy.getPlans() != null && policy.getPlans().getPlans() != null) {
+      for (Plan plan : policy.getPlans().getPlans()) {
+        collectBlocks(plan.getBlocks(), byFile);
+      }
+    }
+
+    if (policy.getFuncs() != null && policy.getFuncs().getFuncs() != null) {
+      for (Func func : policy.getFuncs().getFuncs()) {
+        collectBlocks(func.getBlocks(), byFile);
+      }
+    }
+
+    return byFile;
+  }
+
+  /** Recursively records every statement's range, so nested blocks are walked, not just the top level. */
+  private static void collectBlocks(List<Block> blocks, Map<Integer, Set<Range>> byFile) {
+    if (blocks == null) {
+      return;
+    }
+    for (Block block : blocks) {
+      if (block == null || block.getStmts() == null) {
+        continue;
+      }
+      for (Stmt stmt : block.getStmts()) {
+        collectStmt(stmt, byFile);
+      }
+    }
+  }
+
+  private static void collectStmt(Stmt stmt, Map<Integer, Set<Range>> byFile) {
+    if (stmt == null) {
+      return;
+    }
+    Location location = stmt.getLocation();
+    if (location != null) {
+      byFile.computeIfAbsent(location.getFile(), k -> new LinkedHashSet<>()).add(Range.of(location));
+    }
+    // These are the only Stmt types carrying nested Blocks (an "or" branch, a with-override, a
+    // scan body, a negation). This matches OPA's v1/ir walk.go exactly (Walk's *BlockStmt/*ScanStmt/
+    // *NotStmt/*WithStmt cases). Keep this list in sync if upstream's IR shape changes.
+    if (stmt instanceof BlockStmt blockStmt) {
+      collectBlocks(blockStmt.getBlocks(), byFile);
+    } else if (stmt instanceof WithStmt withStmt && withStmt.getBlock() != null) {
+      collectBlocks(List.of(withStmt.getBlock()), byFile);
+    } else if (stmt instanceof ScanStmt scanStmt && scanStmt.getBlock() != null) {
+      collectBlocks(List.of(scanStmt.getBlock()), byFile);
+    } else if (stmt instanceof NotStmt notStmt && notStmt.getBlock() != null) {
+      collectBlocks(List.of(notStmt.getBlock()), byFile);
+    }
+  }
+
   /** Distinct source rows spanned by {@code ranges}, matching OPA's line-based counts. */
   private static int countLines(Collection<Range> ranges) {
     if (ranges == null || ranges.isEmpty()) {
@@ -115,19 +268,5 @@ public record CoverageReport(
   private static double coveragePercent(int coveredLines, int notCoveredLines) {
     int total = coveredLines + notCoveredLines;
     return total == 0 ? 0.0 : (double) coveredLines / total * 100;
-  }
-
-  private static Map<Integer, List<Range>> notCoveredRangesByFile(
-      List<UnplannedRule> unplannedRules) {
-    Map<Integer, List<Range>> byFile = new HashMap<>();
-    if (unplannedRules == null) {
-      return byFile;
-    }
-    for (UnplannedRule rule : unplannedRules) {
-      byFile
-          .computeIfAbsent(rule.getLocation().getFile(), k -> new ArrayList<>())
-          .add(Range.of(rule.getLocation()));
-    }
-    return byFile;
   }
 }

--- a/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/tracing/CoverageReportTest.java
+++ b/opa-evaluator/src/test/java/io/github/open_policy_agent/opa/tracing/CoverageReportTest.java
@@ -5,7 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.open_policy_agent.opa.ir.Location;
+import io.github.open_policy_agent.opa.ir.policy.Block;
+import io.github.open_policy_agent.opa.ir.policy.Plan;
+import io.github.open_policy_agent.opa.ir.policy.Plans;
+import io.github.open_policy_agent.opa.ir.policy.Policy;
+import io.github.open_policy_agent.opa.ir.policy.Static;
+import io.github.open_policy_agent.opa.ir.policy.StringConst;
 import io.github.open_policy_agent.opa.ir.policy.UnplannedRule;
+import io.github.open_policy_agent.opa.ir.stmts.NopStmt;
+import io.github.open_policy_agent.opa.ir.stmts.Stmt;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -97,5 +105,67 @@ class CoverageReportTest {
     assertEquals(0, report.coveredLines());
     assertEquals(0, report.notCoveredLines());
     assertEquals(0.0, report.coverage());
+  }
+
+  @Test
+  void from_marksRestOfPartlyRunRuleAsNotCovered() {
+    // A single plan (rule body) of two statements, e.g. `false` on row 5 then `another_rule` on
+    // row 6: the evaluator only runs the first before the rule fails, so the second was compiled
+    // (it's in the plan) but never executed and must show up as not covered.
+    Stmt first = new NopStmt(0, 1, 5);
+    Stmt second = new NopStmt(0, 1, 6);
+    Policy policy = policyWithSinglePlan(List.of(first, second));
+
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(first.getLocation(), 0);
+
+    CoverageReport report = CoverageReport.from(profiler, policy);
+
+    CoverageReport.FileCoverage file = report.files().get("policy.rego");
+    assertEquals(1, file.covered().size());
+    assertEquals(5, file.covered().get(0).start().getRow());
+    assertEquals(1, file.notCovered().size());
+    assertEquals(6, file.notCovered().get(0).start().getRow());
+  }
+
+  @Test
+  void from_reportsNothingNotCoveredWhenWholeRuleRuns() {
+    Stmt first = new NopStmt(0, 1, 5);
+    Stmt second = new NopStmt(0, 1, 6);
+    Policy policy = policyWithSinglePlan(List.of(first, second));
+
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(first.getLocation(), 0);
+    profiler.addEntry(second.getLocation(), 0);
+
+    CoverageReport report = CoverageReport.from(profiler, policy);
+
+    CoverageReport.FileCoverage file = report.files().get("policy.rego");
+    assertEquals(2, file.covered().size());
+    assertTrue(file.notCovered().isEmpty());
+  }
+
+  @Test
+  void from_treatsAPlannedRangeAsCoveredWhenContainedInALargerCoveredRange() {
+    // A planned range only needs to fall inside a covered range, not match it exactly, matching
+    // OPA's v1/cover isRangeCovered.
+    Stmt stmt = new NopStmt();
+    stmt.setLocation(0, 5, 3, 5, 8); // row 5, cols 3-8: inside the covered row 5, cols 1-10
+    Policy policy = policyWithSinglePlan(List.of(stmt));
+
+    CoverageProfiler profiler = new CoverageProfiler();
+    profiler.addEntry(new Location(0, 1, 5, 10, 5), 0);
+
+    CoverageReport report = CoverageReport.from(profiler, policy);
+
+    CoverageReport.FileCoverage file = report.files().get("policy.rego");
+    assertTrue(file.notCovered().isEmpty());
+  }
+
+  private static Policy policyWithSinglePlan(List<Stmt> stmts) {
+    Static staticField = new Static(List.of(), List.of(), List.of(new StringConst("policy.rego")));
+    Plan plan = new Plan("data.example", List.of(new Block(stmts)));
+    Plans plans = new Plans(List.of(plan));
+    return new Policy(staticField, plans, null, List.of());
   }
 }


### PR DESCRIPTION
Walk every statement in the IR plan to find ranges that were compiled but never executed in a given run.

This brings the Java implementation here in line with OPA's v1/cover, which reports such gaps in this way. 'Unplanned Rules' are not really a thing in the go path, so this library brings these together to match the OPA output, if not the method for unplanned and thus discarded rules.