### PR TITLE
feat(status): retry status uploads with backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,17 @@ See [opa-services/README.md](opa-services/README.md#tls-and-mtls) for a full mTL
 |-------|------|---------|-------------|
 | `service` | string | - | Service for status reports |
 | `console` | boolean | false | Enable console output |
+| `resource` | string | `/status` | Resource path for status uploads |
+| `min_delay_seconds` | int | 30 | Minimum delay between reports |
+| `max_delay_seconds` | int | 2x min | Maximum delay between reports |
+| `max_retry_attempts` | int | 3 | Retries after a failed upload (0 disables) |
+
+A failed status upload is retried with an exponential backoff. Server errors (5xx), `408`, and
+`429` are treated as transient; any other `4xx` is not retried, since resending the same report
+would fail identically. The whole retry sequence is capped at `min_delay_seconds`, so retries
+never run into the next scheduled report. Status reports are periodic snapshots, so a report
+that still fails after the last attempt is logged and dropped rather than buffered — the next
+tick sends a fresh one.
 
 #### Discovery
 

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/config/Config.java
@@ -465,6 +465,13 @@ public class Config {
     @JsonProperty("max_delay_seconds")
     private Integer maxDelaySeconds;
 
+    /**
+     * Retries attempted after a failed status upload, on top of the initial attempt. 0 disables
+     * retrying. The sequence is additionally capped at the next report interval.
+     */
+    @JsonProperty("max_retry_attempts")
+    private int maxRetryAttempts = 3;
+
     public Boolean getConsole() {
       return console;
     }
@@ -510,6 +517,15 @@ public class Config {
       return this;
     }
 
+    public int getMaxRetryAttempts() {
+      return maxRetryAttempts;
+    }
+
+    public StatusConfig setMaxRetryAttempts(int maxRetryAttempts) {
+      this.maxRetryAttempts = maxRetryAttempts;
+      return this;
+    }
+
     @Override
     public String toString() {
       return "StatusConfig{"
@@ -525,6 +541,8 @@ public class Config {
           + minDelaySeconds
           + ", maxDelaySeconds="
           + maxDelaySeconds
+          + ", maxRetryAttempts="
+          + maxRetryAttempts
           + '}';
     }
   }

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/ServicePlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/ServicePlugin.java
@@ -1,5 +1,6 @@
 package io.github.open_policy_agent.opa.plugins;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -336,15 +337,7 @@ public final class ServicePlugin implements Plugin {
 
     void post(String path, String body) {
 
-      HttpRequest.Builder request =
-          HttpRequest.newBuilder()
-              .uri(buildUri(path))
-              .header("Content-Type", "application/json")
-              .header("Accept", "application/json")
-              .POST(HttpRequest.BodyPublishers.ofString(body));
-
-      request = applyCredentials(request);
-      request = applyHeaders(request);
+      HttpRequest.Builder request = newPostRequest(path, body);
 
       client
           .sendAsync(request.build(), HttpResponse.BodyHandlers.ofString())
@@ -357,6 +350,33 @@ public final class ServicePlugin implements Plugin {
                 logger.error("Failed to send POST request: " + e.getMessage());
                 return null;
               });
+    }
+
+    /**
+     * POST {@code body} to {@code path}, blocking until the response arrives, and return its status
+     * code. Unlike {@link #post}, which is fire-and-forget, this surfaces transport failures (as an
+     * {@link IOException}) and the server's status code, so a caller can decide whether to retry.
+     */
+    int postSync(String path, String body) throws IOException, InterruptedException {
+      // HttpRequest rejects a non-positive timeout, so a service configured with 0 falls back to
+      // the default (mirrors BundleDownloader.requestTimeout).
+      int timeoutSeconds = responseHeaderTimeoutSeconds > 0 ? responseHeaderTimeoutSeconds : 10;
+      HttpRequest request =
+          newPostRequest(path, body).timeout(Duration.ofSeconds(timeoutSeconds)).build();
+
+      return client.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+    }
+
+    private HttpRequest.Builder newPostRequest(String path, String body) {
+      HttpRequest.Builder request =
+          HttpRequest.newBuilder()
+              .uri(buildUri(path))
+              .header("Content-Type", "application/json")
+              .header("Accept", "application/json")
+              .POST(HttpRequest.BodyPublishers.ofString(body));
+
+      request = applyCredentials(request);
+      return applyHeaders(request);
     }
 
     /**

--- a/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
+++ b/opa-services/src/main/java/io/github/open_policy_agent/opa/plugins/StatusPlugin.java
@@ -2,6 +2,7 @@ package io.github.open_policy_agent.opa.plugins;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -67,6 +68,10 @@ public final class StatusPlugin implements Plugin {
               + ")");
     }
 
+    if (statusConfig.getMaxRetryAttempts() < 0) {
+      errors.add("Status max_retry_attempts must be >= 0");
+    }
+
     return errors;
   }
 
@@ -84,7 +89,8 @@ public final class StatusPlugin implements Plugin {
               .setService(statusConfig.getService())
               .setResource(statusConfig.getResource())
               .setMinDelaySeconds(statusConfig.getMinDelaySeconds())
-              .setMaxDelaySeconds(statusConfig.getMaxDelaySeconds());
+              .setMaxDelaySeconds(statusConfig.getMaxDelaySeconds())
+              .setMaxRetryAttempts(statusConfig.getMaxRetryAttempts());
     }
 
     return plugin;
@@ -97,38 +103,47 @@ public final class StatusPlugin implements Plugin {
       return;
     }
 
-    // Get report interval bounds (default: 30 seconds, matching OPA's previous fixed interval;
-    // OPA Go's status plugin has no standalone min/max delay of its own today - reports are
-    // triggered by the bundle/discovery plugin's polling - so there's no upstream number to
-    // mirror here beyond the interval this SDK already used).
-    // - only min set → max defaults to 2 * min
-    // - only max set → min defaults to min(30, max) so a max below 30 is not silently ignored
-    // - neither set → min=30, max=60
-    Integer configuredMin = status.getMinDelaySeconds();
-    Integer configuredMax = status.getMaxDelaySeconds();
-    int minDelaySeconds;
-    int maxDelaySeconds;
-    if (configuredMin != null && configuredMax != null) {
-      minDelaySeconds = configuredMin;
-      maxDelaySeconds = configuredMax;
-    } else if (configuredMin != null) {
-      minDelaySeconds = configuredMin;
-      maxDelaySeconds = configuredMin * 2;
-    } else if (configuredMax != null) {
-      maxDelaySeconds = configuredMax;
-      minDelaySeconds = Math.min(30, configuredMax);
-    } else {
-      minDelaySeconds = 30;
-      maxDelaySeconds = 60;
-    }
+    ReportInterval interval =
+        ReportInterval.of(status.getMinDelaySeconds(), status.getMaxDelaySeconds());
 
     // Report immediately on startup (matches previous behavior), then continue with a jittered
     // chained schedule for subsequent reports - mirrors BundleDownloader.startPolling(), which
     // downloads immediately before starting its own chained poll.
     scheduler.schedule(() -> status.reportStatus(), 0, TimeUnit.SECONDS);
-    scheduleNextReport(minDelaySeconds, maxDelaySeconds);
+    scheduleNextReport(interval.min, interval.max);
 
     manager.updatePluginStatus("status", PluginManager.Status.OK);
+  }
+
+  /**
+   * The bounds of the jittered delay between status reports, defaulting to 30-60 seconds.
+   *
+   * <p>OPA Go's status plugin has no standalone min/max delay of its own today - reports are
+   * triggered by the bundle/discovery plugin's polling - so there's no upstream number to mirror
+   * here beyond the interval this SDK already used.
+   */
+  private static final class ReportInterval {
+    private final int min;
+    private final int max;
+
+    private ReportInterval(int min, int max) {
+      this.min = min;
+      this.max = max;
+    }
+
+    static ReportInterval of(Integer configuredMin, Integer configuredMax) {
+      if (configuredMin != null && configuredMax != null) {
+        return new ReportInterval(configuredMin, configuredMax);
+      }
+      if (configuredMin != null) {
+        return new ReportInterval(configuredMin, configuredMin * 2);
+      }
+      if (configuredMax != null) {
+        // min(30, max) so a max below the default min is not silently ignored.
+        return new ReportInterval(Math.min(30, configuredMax), configuredMax);
+      }
+      return new ReportInterval(30, 60);
+    }
   }
 
   // Re-schedules the next status report with a uniformly random delay in [minDelay, maxDelay],
@@ -183,6 +198,11 @@ public final class StatusPlugin implements Plugin {
   public static class Status {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    private static final long INITIAL_BACKOFF_MILLIS = 1000L;
+
+    /** Ceiling for the doubling, so a long retry budget doesn't produce minutes-long waits. */
+    private static final long MAX_BACKOFF_MILLIS = 30_000L;
+
     private final PluginManager manager;
     private final Logger logger;
     private Boolean console;
@@ -190,6 +210,7 @@ public final class StatusPlugin implements Plugin {
     private String resource;
     private Integer minDelaySeconds;
     private Integer maxDelaySeconds;
+    private int maxRetryAttempts;
 
     private Status(PluginManager manager, Logger logger) {
       this.manager = manager;
@@ -238,6 +259,15 @@ public final class StatusPlugin implements Plugin {
 
     public Status setMaxDelaySeconds(Integer maxDelaySeconds) {
       this.maxDelaySeconds = maxDelaySeconds;
+      return this;
+    }
+
+    public int getMaxRetryAttempts() {
+      return maxRetryAttempts;
+    }
+
+    public Status setMaxRetryAttempts(int maxRetryAttempts) {
+      this.maxRetryAttempts = maxRetryAttempts;
       return this;
     }
 
@@ -317,7 +347,15 @@ public final class StatusPlugin implements Plugin {
       // If status is null, plugin is not registered - don't add to report
     }
 
-    /** Send status report to configured service. */
+    /**
+     * Send the status report to the configured service, retrying transient failures with an
+     * exponential backoff.
+     *
+     * <p>Reports are periodic snapshots, so unlike decision logs there is no buffer to preserve on
+     * final failure - the report is dropped and the next tick sends a fresh one. Retries run on the
+     * calling scheduler thread, which only re-arms the next report once this returns, and the whole
+     * sequence is capped at the shortest interval that report could be scheduled with.
+     */
     private void sendToService(ObjectNode statusReport) {
       // Get ServicePlugin from manager
       Plugin plugin = manager.getPlugin("services");
@@ -334,14 +372,113 @@ public final class StatusPlugin implements Plugin {
         return;
       }
 
-      try {
-        // Determine resource path (default: /status)
-        String path = (resource != null && !resource.isEmpty()) ? resource : "/status";
+      // Determine resource path (default: /status)
+      String path = (resource != null && !resource.isEmpty()) ? resource : "/status";
+      String body = statusReport.toString();
 
-        svc.post(path, statusReport.toString());
-        logger.debug("Status report sent to service '%s'", service);
-      } catch (Exception e) {
-        logger.error("Failed to send status to service '%s': %s", service, e.getMessage());
+      long deadlineNanos =
+          System.nanoTime()
+              + TimeUnit.SECONDS.toNanos(
+                  ReportInterval.of(minDelaySeconds, maxDelaySeconds).min);
+
+      long backoffMillis = INITIAL_BACKOFF_MILLIS;
+      int attempt = 0;
+      while (true) {
+        attempt++;
+        Attempt result = postOnce(svc, path, body);
+        if (result.succeeded) {
+          logger.debug("Status report sent to service '%s'", service);
+          return;
+        }
+
+        if (!result.retryable || attempt > maxRetryAttempts) {
+          logger.error(
+              "Failed to send status to service '%s' after %d attempt(s): %s",
+              service, attempt, result.detail);
+          return;
+        }
+
+        long sleepMillis = Math.min(jitter(backoffMillis), remainingMillis(deadlineNanos));
+        if (sleepMillis <= 0) {
+          logger.error(
+              "Failed to send status to service '%s' after %d attempt(s), retry budget exhausted: %s",
+              service, attempt, result.detail);
+          return;
+        }
+
+        logger.debug(
+            "Status report to service '%s' failed (%s); retrying in %dms",
+            service, result.detail, sleepMillis);
+        try {
+          Thread.sleep(sleepMillis);
+        } catch (InterruptedException e) {
+          // Plugin shutdown interrupts the scheduler thread: stop retrying and let it unwind.
+          Thread.currentThread().interrupt();
+          logger.warn("Interrupted while retrying status report to service '%s'", service);
+          return;
+        }
+
+        backoffMillis = Math.min(backoffMillis * 2, MAX_BACKOFF_MILLIS);
+      }
+    }
+
+    private Attempt postOnce(ServicePlugin.Service svc, String path, String body) {
+      try {
+        int statusCode = svc.postSync(path, body);
+        if (statusCode >= 200 && statusCode < 300) {
+          return Attempt.SUCCESS;
+        }
+        return Attempt.failed(isRetryableStatus(statusCode), "HTTP " + statusCode);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return Attempt.failed(false, "interrupted");
+      } catch (IOException e) {
+        // Connection refused, connection reset, request timeout: transient by nature.
+        return Attempt.failed(true, describe(e));
+      } catch (RuntimeException e) {
+        // A malformed resource URI or an unsupported credential type won't fix itself.
+        return Attempt.failed(false, describe(e));
+      }
+    }
+
+    /**
+     * Server errors and an explicit "slow down" are worth another attempt; every other 4xx is the
+     * client's fault (bad path, bad credentials) and will fail identically on a resend.
+     */
+    private static boolean isRetryableStatus(int statusCode) {
+      return statusCode >= 500 || statusCode == 429 || statusCode == 408;
+    }
+
+    // Spread over [half, full] so instances knocked offline by one outage don't retry in lockstep.
+    private static long jitter(long backoffMillis) {
+      return ThreadLocalRandom.current().nextLong(backoffMillis / 2, backoffMillis + 1);
+    }
+
+    private static long remainingMillis(long deadlineNanos) {
+      return TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+    }
+
+    // Not every exception carries a message, so fall back to the type name rather than "null".
+    private static String describe(Throwable t) {
+      return t.getMessage() != null ? t.getMessage() : t.toString();
+    }
+
+    /** The outcome of one upload attempt: whether it worked, and if not, whether to try again. */
+    private static final class Attempt {
+      private static final Attempt SUCCESS = new Attempt(true, false, null);
+
+      private final boolean succeeded;
+      private final boolean retryable;
+      private final String detail;
+
+      private Attempt(boolean succeeded, boolean retryable, String detail) {
+        this.succeeded = succeeded;
+        this.retryable = retryable;
+        this.detail = detail;
+      }
+
+      static Attempt failed(boolean retryable, String detail) {
+        return new Attempt(false, retryable, detail);
       }
     }
   }

--- a/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
+++ b/opa-services/src/test/java/io/github/open_policy_agent/opa/plugins/StatusPluginTest.java
@@ -1,12 +1,20 @@
 package io.github.open_policy_agent.opa.plugins;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import io.github.open_policy_agent.opa.config.Config;
@@ -25,6 +33,11 @@ class StatusPluginTest {
   private Logger mockLogger;
   private Store store;
   private Config config;
+  private HttpServer server;
+  private ServicePlugin servicePlugin;
+
+  /** One entry per status upload the test server received, in arrival order. */
+  private final List<String> uploads = new CopyOnWriteArrayList<>();
 
   @BeforeEach
   void setUp() {
@@ -36,6 +49,16 @@ class StatusPluginTest {
     Config.ServiceConfig service =
         new Config.ServiceConfig().setName("test-service").setUrl("https://example.com");
     config.setServices(Collections.singletonMap("test-service", service));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (servicePlugin != null) {
+      servicePlugin.stop();
+    }
+    if (server != null) {
+      server.stop(0);
+    }
   }
 
   @Test
@@ -208,6 +231,26 @@ class StatusPluginTest {
   }
 
   @Test
+  void validate_negativeMaxRetryAttempts_returnsError() {
+    Config.StatusConfig status =
+        new Config.StatusConfig().setService("test-service").setMaxRetryAttempts(-1);
+    config.setStatus(status);
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    StatusPlugin plugin = new StatusPlugin();
+    Set<String> errors = plugin.validate(manager);
+
+    assertTrue(errors.stream().anyMatch(e -> e.contains("max_retry_attempts must be >= 0")));
+  }
+
+  @Test
   void initialize_noStatusConfigured_returnsPlugin() {
     manager =
         new PluginManager.Builder()
@@ -354,6 +397,11 @@ class StatusPluginTest {
 
     assertFalse(status.getConsole());
     assertEquals("/status", status.getResource());
+  }
+
+  @Test
+  void configDefaults_maxRetryAttempts() {
+    assertEquals(3, new Config.StatusConfig().getMaxRetryAttempts());
   }
 
   @Test
@@ -540,46 +588,114 @@ class StatusPluginTest {
 
   @Test
   void statusReport_sendsToService() throws Exception {
-    Config.StatusConfig status =
-        new Config.StatusConfig().setService("test-service").setConsole(false);
-    config.setStatus(status);
+    StatusPlugin.Status statusReporter =
+        statusReporterAgainstServer(new Config.StatusConfig().setConsole(false), 200);
 
-    manager =
-        new PluginManager.Builder()
-            .withId("test-opa")
-            .withStore(store)
-            .withConfig(config)
-            .withLogger(mockLogger)
-            .build();
+    statusReporter.reportStatus();
 
-    // Initialize ServicePlugin first
-    ServicePlugin servicePlugin = new ServicePlugin();
-    servicePlugin = (ServicePlugin) servicePlugin.initialize(manager);
-    servicePlugin.start();
+    assertEquals(1, uploads.size(), "a healthy endpoint should be posted to exactly once");
+    verify(mockLogger, atLeastOnce())
+        .debug(eq("Status report sent to service '%s'"), eq("test-service"));
+  }
 
-    // Register the ServicePlugin with PluginManager
-    java.lang.reflect.Field pluginsField = PluginManager.class.getDeclaredField("plugins");
-    pluginsField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    Map<String, Plugin> plugins = (Map<String, Plugin>) pluginsField.get(manager);
-    plugins.put("services", servicePlugin);
+  @Test
+  void statusReport_transientFailureThenSuccess_retriesAndDelivers() throws Exception {
+    // A 503 on the first attempt used to drop the report until the next tick.
+    StatusPlugin.Status statusReporter =
+        statusReporterAgainstServer(
+            new Config.StatusConfig().setConsole(false).setMinDelaySeconds(30), 503, 200);
 
-    // Initialize StatusPlugin
-    StatusPlugin plugin = new StatusPlugin();
-    plugin = (StatusPlugin) plugin.initialize(manager);
+    statusReporter.reportStatus();
 
-    // Access the status reporter via reflection to trigger a report manually
-    java.lang.reflect.Field statusField = StatusPlugin.class.getDeclaredField("status");
-    statusField.setAccessible(true);
-    StatusPlugin.Status statusReporter = (StatusPlugin.Status) statusField.get(plugin);
+    assertEquals(2, uploads.size(), "expected a retry after the 503");
+    verify(mockLogger, atLeastOnce())
+        .debug(eq("Status report sent to service '%s'"), eq("test-service"));
+    verify(mockLogger, never()).error(startsWith("Failed to send status"), any(), any(), any());
+  }
 
-    if (statusReporter != null) {
-      statusReporter.reportStatus();
+  @Test
+  void statusReport_permanentFailure_isNotRetried() throws Exception {
+    // Resending a report the server rejected only burns the budget the next report needs.
+    StatusPlugin.Status statusReporter =
+        statusReporterAgainstServer(
+            new Config.StatusConfig().setConsole(false).setMinDelaySeconds(30), 400);
 
-      // Verify debug log for sending to service
-      verify(mockLogger, atLeastOnce())
-          .debug(eq("Status report sent to service '%s'"), eq("test-service"));
-    }
+    statusReporter.reportStatus();
+
+    assertEquals(1, uploads.size(), "a 4xx must not be retried");
+    verify(mockLogger)
+        .error(
+            eq("Failed to send status to service '%s' after %d attempt(s): %s"),
+            eq("test-service"),
+            eq(1),
+            eq("HTTP 400"));
+  }
+
+  @Test
+  void statusReport_persistentServerError_stopsAtMaxRetryAttempts() throws Exception {
+    StatusPlugin.Status statusReporter =
+        statusReporterAgainstServer(
+            new Config.StatusConfig()
+                .setConsole(false)
+                .setMinDelaySeconds(30)
+                .setMaxRetryAttempts(2),
+            500);
+
+    statusReporter.reportStatus();
+
+    assertEquals(3, uploads.size(), "expected the initial attempt plus 2 retries");
+    verify(mockLogger)
+        .error(
+            eq("Failed to send status to service '%s' after %d attempt(s): %s"),
+            eq("test-service"),
+            eq(3),
+            eq("HTTP 500"));
+  }
+
+  @Test
+  void statusReport_retryBudget_isCappedAtTheNextReportInterval() throws Exception {
+    // 10 exponential retries would run for over a minute; with reports due every second, the
+    // sequence has to stop after ~1s so it never overlaps the next tick.
+    StatusPlugin.Status statusReporter =
+        statusReporterAgainstServer(
+            new Config.StatusConfig()
+                .setConsole(false)
+                .setMinDelaySeconds(1)
+                .setMaxDelaySeconds(1)
+                .setMaxRetryAttempts(10),
+            500);
+
+    long startNanos = System.nanoTime();
+    statusReporter.reportStatus();
+    long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000;
+
+    assertTrue(
+        elapsedMillis < 3000,
+        "retries should stop within the 1s budget, but took " + elapsedMillis + "ms");
+    assertTrue(uploads.size() < 11, "budget should cut the sequence short of max_retry_attempts");
+    verify(mockLogger)
+        .error(
+            eq(
+                "Failed to send status to service '%s' after %d attempt(s), retry budget"
+                    + " exhausted: %s"),
+            eq("test-service"),
+            anyInt(),
+            eq("HTTP 500"));
+  }
+
+  @Test
+  void statusReport_retriesDisabled_sendsOnce() throws Exception {
+    StatusPlugin.Status statusReporter =
+        statusReporterAgainstServer(
+            new Config.StatusConfig()
+                .setConsole(false)
+                .setMinDelaySeconds(30)
+                .setMaxRetryAttempts(0),
+            500);
+
+    statusReporter.reportStatus();
+
+    assertEquals(1, uploads.size(), "max_retry_attempts=0 disables retrying");
   }
 
   @Test
@@ -620,6 +736,60 @@ class StatusPluginTest {
 
   private ObjectNode buildStatusReport(StatusPlugin plugin) throws Exception {
     return buildStatusReport(getStatusReporter(plugin));
+  }
+
+  /**
+   * Returns a status reporter wired to a local server that answers each request with the next code
+   * in {@code responseCodes}, repeating the last one once they run out.
+   */
+  private StatusPlugin.Status statusReporterAgainstServer(
+      Config.StatusConfig statusConfig, int... responseCodes) throws Exception {
+    startServer(responseCodes);
+
+    config.setServices(
+        Collections.singletonMap(
+            "test-service",
+            new Config.ServiceConfig()
+                .setName("test-service")
+                .setUrl("http://localhost:" + server.getAddress().getPort())));
+    config.setStatus(statusConfig.setService("test-service"));
+
+    manager =
+        new PluginManager.Builder()
+            .withId("test-opa")
+            .withStore(store)
+            .withConfig(config)
+            .withLogger(mockLogger)
+            .build();
+
+    servicePlugin = (ServicePlugin) new ServicePlugin().initialize(manager);
+    servicePlugin.start();
+
+    // Register the ServicePlugin with PluginManager
+    java.lang.reflect.Field pluginsField = PluginManager.class.getDeclaredField("plugins");
+    pluginsField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, Plugin> plugins = (Map<String, Plugin>) pluginsField.get(manager);
+    plugins.put("services", servicePlugin);
+
+    StatusPlugin.Status statusReporter =
+        getStatusReporter((StatusPlugin) new StatusPlugin().initialize(manager));
+    assertNotNull(statusReporter, "status reporter should have been wired from the config");
+    return statusReporter;
+  }
+
+  private void startServer(int... responseCodes) throws IOException {
+    AtomicInteger nextResponse = new AtomicInteger();
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.createContext(
+        "/status",
+        exchange -> {
+          uploads.add(new String(exchange.getRequestBody().readAllBytes(), UTF_8));
+          int index = Math.min(nextResponse.getAndIncrement(), responseCodes.length - 1);
+          exchange.sendResponseHeaders(responseCodes[index], -1);
+          exchange.close();
+        });
+    server.start();
   }
 
   private static StatusPlugin.Status getStatusReporter(StatusPlugin plugin) throws Exception {


### PR DESCRIPTION
`StatusPlugin` caught and logged upload failures, then dropped the report, so a transient blip left a gap in ops dashboards until the next tick. Uploads are now retried with a jittered exponential backoff — 5xx/408/429 and transport errors are transient, other 4xx are not — bounded by a new `status.max_retry_attempts` (default 3) and by the next report interval, so retries never run into the following tick. This required a blocking `Service.postSync` that surfaces the status code, since the existing fire-and-forget `post` reports nothing back.

Fixes #83